### PR TITLE
Add GitHub Pages deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
   push:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
-
-# Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
   pages: write
@@ -20,12 +15,11 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+
       - name: Install, build, and upload your site output
         uses: withastro/action@v4
-        # with:
-        # path: . # The root location of your Astro project inside the repository. (optional)
-        # node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
-        # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        with:
+          package-manager: pnpm@10
 
   deploy:
     needs: build

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,7 @@
 {
-  "recommendations": ["astro-build.astro-vscode", "stripe.markdoc-language-support"],
+  "recommendations": [
+    "astro-build.astro-vscode",
+    "unifiedjs.vscode-mdx"
+  ],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
This pull request adds a GitHub Pages deployment pipeline to automatically deploy the documentation site.

## Changes included:
- ✨ **CD pipeline to GitHub Pages**: Added automated deployment workflow
- 🔧 **GitHub Actions workflow updates**: Updated workflow configuration for proper deployment
- 📝 **VSCode extensions recommendations**: Updated recommended extensions for better development experience

## Benefits:
- Automated deployment of documentation changes
- Consistent and reliable deployment process
- Better development workflow with updated tooling

The deployment pipeline will automatically build and deploy the Astro-based documentation site to GitHub Pages whenever changes are merged to the main branch.