### PR TITLE
Adding Node client docgen script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pnpm-debug.log*
 
 # VS-Code specific files
 .vscode/
+
+doc-gen/docs/

--- a/doc-gen/build-node-docs.sh
+++ b/doc-gen/build-node-docs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Valkey Glide Docgen
+# This script installs dependencies, builds the project, and generates documentation
+
+set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_LOCATION=$SCRIPT_DIR/docs/node/
+
+if [ -n "$1" ]; then
+    NODE_CLIENT_DIR="$1"
+else
+    NODE_CLIENT_DIR="$SCRIPT_DIR/valkey-glide/node"
+fi
+
+if [ ! -d "$NODE_CLIENT_DIR" ]; then
+    echo "Error: Directory $NODE_CLIENT_DIR does not exist"
+    exit 1
+fi
+
+cd "$NODE_CLIENT_DIR"
+npm install typedoc
+npm run build
+npx typedoc --options $SCRIPT_DIR/typedoc.json --out $OUT_LOCATION
+
+echo "Node client documentation generated successfully!"
+echo "Output location: $OUT_LOCATION"

--- a/doc-gen/typedoc.json
+++ b/doc-gen/typedoc.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://typedoc.org/schema.json",
+    "entryPoints": [
+        "valkey-glide/node/src/BaseClient.ts",
+        "valkey-glide/node/src/Batch.ts",
+        "valkey-glide/node/src/GlideClient.ts",
+        "valkey-glide/node/src/GlideClusterClient.ts",
+        "valkey-glide/node/src/Errors.ts",
+        "valkey-glide/node/src/Commands.ts",
+        "valkey-glide/node/src/Logger.ts",
+        "valkey-glide/node/src/server-modules/GlideFt.ts",
+        "valkey-glide/node/src/server-modules/FtOptions.ts",
+        "valkey-glide/node/src/server-modules/GlideJson.ts"
+    ],
+    "disableSources": true,
+    "includeHierarchySummary": true
+}


### PR DESCRIPTION
## Add script to generate Node client documentation

Adds `build-node-docs.sh` to automate TypeDoc documentation generation for the Node client.

**Usage:**
```bash
./build-node-docs.sh [optional-node-client-path]
```

**Features:**
- Validates directory exists
- Installs dependencies and builds project
- Generates docs to `docs/node/`
- Configurable client directory path