### PR TITLE
Added Java client doc gen

### DIFF
--- a/doc-gen/build-java-docs.sh
+++ b/doc-gen/build-java-docs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Valkey Glide Java Docgen Script
+# This script generate Javadoc for the Java client.
+
+set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_LOCATION=$SCRIPT_DIR/docs/java/
+
+if [ -n "$1" ]; then
+    JAVA_CLIENT_DIR="$1"
+else
+    JAVA_CLIENT_DIR="$SCRIPT_DIR/valkey-glide/java"
+fi
+
+if [ ! -d "$JAVA_CLIENT_DIR" ]; then
+    echo "Error: Directory $JAVA_CLIENT_DIR does not exist"
+    exit 1
+fi
+
+cd "$JAVA_CLIENT_DIR"
+
+# We use a temporary init script to configure the javadoc task
+# to avoid modifying the original build.gradle file.
+INIT_SCRIPT=$(mktemp)
+cat > "$INIT_SCRIPT" << EOF
+    allprojects {
+        tasks.withType(Javadoc) {
+            exclude '**/module-info.java.disabled'
+            exclude '**/module-info.java'
+            destinationDir = file("$OUT_LOCATION")
+        }
+    }
+EOF
+
+./gradlew :client:javadoc --init-script "$INIT_SCRIPT"
+
+echo "Java client documentation generated successfully!"
+echo "Javadoc output location: $OUT_LOCATION"
+
+# Clean up
+rm -f "$INIT_SCRIPT"


### PR DESCRIPTION
## Add script to generate Java client documentation

Adds `build-java-docs.sh` to automate Javadoc generation for the Java client using Gradle.

**Usage:**
```bash
./build-java-docs.sh [optional-java-client-path]
```

**Features:**
- Validates directory exists
- Uses temporary Gradle init script (non-invasive)
- Excludes module-info files from Javadoc
- Generates docs to `docs/java/`
- Configurable client directory path
- Automatic cleanup