### PR TITLE
Fixed tls_advanced_configuration to tls_config

### DIFF
--- a/src/content/docs/languages/python/how-to/TLS.mdx
+++ b/src/content/docs/languages/python/how-to/TLS.mdx
@@ -69,7 +69,7 @@ from glide import (
 tls_config = TlsAdvancedConfiguration(use_insecure_tls=True)
 
 advanced_config = AdvancedGlideClusterClientConfiguration(
-    tls_advanced_configuration=tls_config
+    tls_config=tls_config
 )
 
 addresses = [NodeAddress(host="address.example.com", port=6379)]
@@ -110,7 +110,7 @@ with open("/path/to/ca-cert.pem", "rb") as f:
 tls_config = TlsAdvancedConfiguration(root_pem_cacerts=root_cert)
 
 advanced_config = AdvancedGlideClusterClientConfiguration(
-    tls_advanced_configuration=tls_config
+    tls_config=tls_config
 )
 
 addresses = [NodeAddress(host="address.example.com", port=6379)]
@@ -142,7 +142,7 @@ MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKmzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
 tls_config = TlsAdvancedConfiguration(root_pem_cacerts=cert_data)
 
 advanced_config = AdvancedGlideClientConfiguration(
-    tls_advanced_configuration=tls_config
+    tls_config=tls_config
 )
 
 addresses = [NodeAddress(host="primary.example.com", port=6379)]
@@ -180,7 +180,7 @@ combined_certs = cert1 + cert2 + cert3
 tls_config = TlsAdvancedConfiguration(root_pem_cacerts=combined_certs)
 
 advanced_config = AdvancedGlideClusterClientConfiguration(
-    tls_advanced_configuration=tls_config
+    tls_config=tls_config
 )
 
 addresses = [NodeAddress(host="address.example.com", port=6379)]
@@ -213,7 +213,7 @@ tls_config = TlsAdvancedConfiguration(
 )
 
 advanced_config = AdvancedGlideClientConfiguration(
-    tls_advanced_configuration=tls_config
+    tls_config=tls_config
 )
 
 addresses = [NodeAddress(host="primary.example.com", port=6379)]

--- a/src/content/docs/languages/python/migration/redis-py/index.mdx
+++ b/src/content/docs/languages/python/migration/redis-py/index.mdx
@@ -80,7 +80,7 @@ For more on advanced configurations, refer to the <a href={`/languages/python`}>
         ),
         advanced_configuration=AdvancedGlideClientConfiguration(
             connection_timeout=5000,
-            tls_advanced_configuration=TlsAdvancedConfiguration(
+            tls_config=TlsAdvancedConfiguration(
                 use_insecure_tls=False
             )
         )
@@ -150,7 +150,7 @@ For more on advanced configurations, refer to the <a href={`/languages/python`}>
         ),
         advanced_configuration=AdvancedGlideClusterClientConfiguration(
             connection_timeout=5000,
-            tls_advanced_configuration=TlsAdvancedConfiguration(
+            tls_config=TlsAdvancedConfiguration(
                 use_insecure_tls=False
             )
         )

--- a/src/content/docs/tutorials/tls.mdx
+++ b/src/content/docs/tutorials/tls.mdx
@@ -147,7 +147,7 @@ This is handled by configuring the `TlsAdvancedConfiguration` and `AdvancedGlide
 
         ```python
         advanced_config = AdvancedGlideClientConfiguration(
-            tls_advanced_configuration=tls_config
+            tls_config=tls_config
         )
         ```
 
@@ -202,7 +202,7 @@ async def main_with_custom_cert():
 
     # 3. Create advanced client configuration
     advanced_config = AdvancedGlideClientConfiguration(
-        tls_advanced_configuration=tls_config
+        tls_config=tls_config
     )
 
     # 4. Create main client configuration


### PR DESCRIPTION
Python examples uses the incorrect tls option `tls_advanced_configuration`. It should be `tls_config` instead.