### PR TITLE
Adding Google Tag Manager header and body scripts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,35 +24,20 @@ function collapsed(isCollapsed = false, sidebarItems) {
   });
 }
 
-const googleAnalyticsId = '<YOUR-GOOGLE-ID>'
 const isDev = process.argv.includes('dev');
-const googleAnalyticsHeaders = isDev ? [] : [
-        {
-          tag: 'script',
-          attrs: {
-            src: `https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`,
-          },
-        },
-        {
-          tag: 'script',
-          content: `
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          
-          // Do this to remain compliant with GDPR.
-          // We do not need to show a cookie consent banner.
-          gtag("consent", "default", {
-              ad_storage: "denied",
-              ad_user_data: "denied",
-              ad_personalization: "denied",
-              analytics_storage: "denied",
-          });
-
-          gtag('config', '${googleAnalyticsId}');
-          `,
-        },
+const googleTagManagerHeader = isDev ? [] : [
+  {
+    tag: /** @type {const} */ ('script'),
+    content: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-5SQ3G3KB');`,
+  },
 ];
+const googleTagManagerBody = isDev ? {} : {
+  SkipLink: './src/components/SkipLinkWithGTM.astro',
+}
 
 export default defineConfig({
   site: "https://glide.valkey.io",
@@ -63,7 +48,8 @@ export default defineConfig({
     }),
     starlight({
       title: "Valkey Glide",
-      head: [...googleAnalyticsHeaders],
+      head: [...googleTagManagerHeader],
+      components: {...googleTagManagerBody},
       logo: {
         light: "./src/assets/valkey-glide-logo-with-name-light.svg",
         dark: "./src/assets/valkey-glide-logo-with-name-dark.svg",

--- a/src/components/SkipLinkWithGTM.astro
+++ b/src/components/SkipLinkWithGTM.astro
@@ -1,0 +1,20 @@
+---
+import Default from '@astrojs/starlight/components/SkipLink.astro';
+---
+
+<!-- 
+This component simply add Google Tag Manager to before the SkipLink
+component. SkipLink is always rendered first in the body before the pageframe.
+It is a simple <a> element so overriding is safe.
+-->
+<noscript slot="before-content">
+  <iframe 
+    src="https://www.googletagmanager.com/ns.html?id=GTM-5SQ3G3KB"
+    height="0" 
+    width="0" 
+    style="display:none;visibility:hidden">
+  </iframe>
+</noscript>
+<Default {...Astro.props}>
+  <slot />
+</Default>


### PR DESCRIPTION
Adding the Google Analytics tags to the site header and body.
- The header script is added through the config file.
- The body script is added through a wrapper component.