### PR TITLE
Add Windows (x86_64) platform support section 

### DIFF
--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -56,9 +56,9 @@ Note: Currently Alpine Linux / MUSL is NOT supported.
 * macOS 14.7 (Apple silicon/aarch\_64)
 * macOS 13.7 (x86\_64/amd64)
 
-:::caution[Windows]
-Windows is not yet supported.
-:::
+### Windows
+Windows support is currently available only for Valkey-GLIDE Java
+* Windows (x86\_64)
 
 ## Install Valkey GLIDE
 

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -59,6 +59,14 @@ export const mavenExample =
     <classifier>linux-x86_64</classifier>
     <version>${javaGlideLatest}</version>
 </dependency>
+
+<!-- windows-x86_64 -->
+<dependency>
+    <groupId>io.valkey</groupId>
+    <artifactId>valkey-glide</artifactId>
+    <classifier>windows-x86_64</classifier>
+    <version>${javaGlideLatest}</version>
+</dependency>
 `
 
 
@@ -94,9 +102,10 @@ Currently Alpine Linux / MUSL is NOT supported.
 * macOS 13.7 (x86\_64/amd64)
 
 
-:::caution[Windows Support]
-Windows is not yet supported.
-:::
+### Windows
+Windows support is currently available only for Valkey-GLIDE Java
+* Windows (x86\_64)
+
 
 ## Installing and Setting Up
 
@@ -138,11 +147,14 @@ Windows is not yet supported.
     linux-x86_64
     linux_musl-aarch_64
     linux_musl-x86_64
+    windows-x86_64
     ```
     :::
 
     <Tabs syncKey="javaBuildTool">
         <TabItem label="Gradle">
+
+            Example with osdector:
             ```groovy
             // with osdetector
             plugins {
@@ -151,25 +163,45 @@ Windows is not yet supported.
             dependencies {
                 implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
             }
+            ```
 
+            Example with osx-aarch_64:
+            ```groovy
             // osx-aarch_64
             dependencies {
                 implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
             }
+            ```
 
+            Example with osx-x86_64:
+            ```groovy
             // osx-x86_64
             dependencies {
                 implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
             }
+            ```
 
+            Example with linux-aarch_64:
+            ```groovy
             // linux-aarch_64
             dependencies {
                 implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
             }
+            ```
 
+            Example with linux-x86_64:
+            ```groovy
             // linux-x86_64
             dependencies {
                 implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
+            }
+            ```
+
+            Example with windows-x86_64:
+            ```groovy
+            // windows-x86_64
+            dependencies {
+                implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'windows-x86_64'
             }
             ```
         </TabItem>
@@ -193,6 +225,9 @@ Windows is not yet supported.
 
             // linux-x86_64
             libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "linux-x86_64"
+
+            // windows-x86_64
+            libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "windows-x86_64"
             ```
         </TabItem>
     </Tabs>

--- a/src/content/docs/languages/java/getting-started/getting-started.mdx
+++ b/src/content/docs/languages/java/getting-started/getting-started.mdx
@@ -74,6 +74,7 @@ osx-aarch_64
 osx-x86_64
 linux-aarch_64
 linux-x86_64
+windows-x86_64
 ```
 
 <Tabs syncKey="javaBuildTool">
@@ -83,27 +84,8 @@ linux-x86_64
       * Must include a `classifier` to specify your platform.
     </Aside>
 
+    Example with osdector:
     ```groovy
-    // osx-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
-    }
-
-    // osx-x86_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
-    }
-
-    // linux-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
-    }
-
-    // linux-x86_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
-    }
-
     // with osdetector
     plugins {
         id "com.google.osdetector" version "1.7.3"
@@ -112,6 +94,47 @@ linux-x86_64
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
     }
     ```
+
+    Example with osx-aarch_64:
+    ```groovy
+    // osx-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
+    }
+    ```
+
+    Example with osx-x86_64:
+    ```groovy
+    // osx-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
+    }
+    ```
+
+    Example with linux-aarch_64:
+    ```groovy
+    // linux-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
+    }
+    ```
+
+    Example with linux-x86_64:
+    ```groovy
+    // linux-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
+    }
+    ```
+
+    Example with windows-x86_64:
+    ```groovy
+    // windows-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'windows-x86_64'
+    }
+    ```
+
   </TabItem>
 
   {/* export const mycode = {` */}
@@ -156,6 +179,14 @@ linux-x86_64
       <version>${javaGlideLatest}</version>
   </dependency>
 
+  <!-- windows-x86_64 -->
+  <dependency>
+      <groupId>io.valkey</groupId>
+      <artifactId>valkey-glide</artifactId>
+      <classifier>windows-x86_64</classifier>
+      <version>${javaGlideLatest}</version>
+  </dependency>
+
   <!-- with os-maven-plugin -->
 
   <build>
@@ -195,6 +226,9 @@ linux-x86_64
 
     // linux-x86_64
     libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "linux-x86_64"
+
+    // windows-x86_64
+    libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "windows-x86_64"
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/languages/java/migration/jedis/Manual Migrations/Installation.mdx
+++ b/src/content/docs/languages/java/migration/jedis/Manual Migrations/Installation.mdx
@@ -34,28 +34,54 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
   <TabItem label="Gradle">
     <Aside>must include a `classifier` to specify your platform.</Aside>
 
+    Example with osdector:
     ```groovy
-    // osx-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
-    }
-
-    // linux-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
-    }
-
-    // linux-x86_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
-    }
-
     // with osdetector
     plugins {
         id "com.google.osdetector" version "1.7.3"
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with osx-aarch_64:
+    ```groovy
+    // osx-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
+    }
+    ```
+
+    Example with osx-x86_64:
+    ```groovy
+    // osx-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
+    }
+    ```
+
+    Example with linux-aarch_64:
+    ```groovy
+    // linux-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
+    }
+    ```
+
+    Example with linux-x86_64:
+    ```groovy
+    // linux-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
+    }
+    ```
+
+    Example with windows-x86_64:
+    ```groovy
+    // windows-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'windows-x86_64'
     }
     ```
   </TabItem>

--- a/src/content/docs/languages/java/migration/lettuce/Installation.mdx
+++ b/src/content/docs/languages/java/migration/lettuce/Installation.mdx
@@ -35,28 +35,54 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
   <TabItem label="Gradle">
     <Aside>must include a `classifier` to specify your platform.</Aside>
 
+    Example with osdector:
     ```groovy
-    // osx-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
-    }
-
-    // linux-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
-    }
-
-    // linux-x86_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
-    }
-
     // with osdetector
     plugins {
         id "com.google.osdetector" version "1.7.3"
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with osx-aarch_64:
+    ```groovy
+    // osx-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
+    }
+    ```
+
+    Example with osx-x86_64:
+    ```groovy
+    // osx-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
+    }
+    ```
+
+    Example with linux-aarch_64:
+    ```groovy
+    // linux-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
+    }
+    ```
+
+    Example with linux-x86_64:
+    ```groovy
+    // linux-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
+    }
+    ```
+
+    Example with windows-x86_64:
+    ```groovy
+    // windows-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'windows-x86_64'
     }
     ```
   </TabItem>

--- a/src/content/docs/languages/java/migration/redisson/Installation.mdx
+++ b/src/content/docs/languages/java/migration/redisson/Installation.mdx
@@ -34,28 +34,54 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
   <TabItem label="Gradle">
     <Aside>must include a `classifier` to specify your platform.</Aside>
 
+    Example with osdector:
     ```groovy
-    // osx-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
-    }
-
-    // linux-aarch_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
-    }
-
-    // linux-x86_64
-    dependencies {
-        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
-    }
-
     // with osdetector
     plugins {
         id "com.google.osdetector" version "1.7.3"
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with osx-aarch_64:
+    ```groovy
+    // osx-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-aarch_64'
+    }
+    ```
+
+    Example with osx-x86_64:
+    ```groovy
+    // osx-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'osx-x86_64'
+    }
+    ```
+
+    Example with linux-aarch_64:
+    ```groovy
+    // linux-aarch_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-aarch_64'
+    }
+    ```
+
+    Example with linux-x86_64:
+    ```groovy
+    // linux-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'linux-x86_64'
+    }
+    ```
+
+    Example with windows-x86_64:
+    ```groovy
+    // windows-x86_64
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: 'windows-x86_64'
     }
     ```
   </TabItem>


### PR DESCRIPTION
- Add Windows (x86_64) platform support section to quickstart guide
- Update installation guide with Windows-specific Maven dependency configuration
- Add windows-x86_64 classifier to Gradle dependency examples with osdetector and manual configuration
- Add windows-x86_64 classifier to Scala/SBT dependency examples
- Clarify that Windows support is currently limited to Java client only
- Update caution notice to specify Windows unsupported for Python, Node, and Go
- Include windows-x86_64 in supported platform classifiers list across all documentation