### PR TITLE
Add dynamic pubsub docs

### DIFF
--- a/src/content/docs/concepts/client-features/pubsub-model.mdx
+++ b/src/content/docs/concepts/client-features/pubsub-model.mdx
@@ -12,18 +12,73 @@ GLIDE is also responsible for tracking topology changes in real time, ensuring t
 Conceptually, the PubSub functionality can be divided into four actions: Subscribing, Publishing, Receiving, and Unsubscribing.
 
 :::note[PHP PubSub Model]
-PHP GLIDE uses a different PubSub model based on the PHPRedis API. Instead of immutable subscription configuration during client creation, PHP uses traditional method calls like `subscribe()`, `psubscribe()`, `publish()`, and `unsubscribe()` with callback functions.
+PHP GLIDE uses a different PubSub model based on the PHPRedis API. Instead of config-based subscriptions, PHP uses blocking method calls like `subscribe()` and `psubscribe()` that enter a message loop with a callback. Unsubscribing is done from within the callback via `unsubscribe()` / `punsubscribe()`. PHP does not have a lazy/blocking distinction — all subscribe calls are blocking.
 :::
+
+GLIDE supports two subscription models:
+
+* **Static (config-based):** Subscriptions defined at client creation time as part of the initial configuration.
+* **Dynamic (GLIDE 2.3+):** Subscriptions added or removed at runtime via explicit API calls.
+
+Both models can coexist on the same client — you can define initial subscriptions in the config and later add or remove subscriptions dynamically. In both cases, GLIDE automatically restores subscription state after topology changes or server disconnects via the PubSub Synchronizer.
+
+## PubSub Synchronizer
+
+At the heart of GLIDE's PubSub implementation is the **PubSub Synchronizer**, a background component that manages the lifecycle of all subscriptions — both static and dynamic.
+
+The synchronizer maintains two separate views of subscription state:
+
+* **Desired state:** What the user wants to be subscribed to. Modified by API calls (`subscribe`, `unsubscribe`, etc.) and by the initial config.
+* **Actual state:** What the server has confirmed via push notifications. Tracked per server address for cluster topology awareness.
+
+A **background reconciliation task** runs continuously, waking either on an explicit trigger (e.g., a new subscribe/unsubscribe call, a topology change, or a disconnection) or on a periodic interval (default: every 3 seconds). Incoming push notifications from the server continuously update the actual subscription state, and the next reconciliation cycle picks up any discrepancies. Each reconciliation cycle:
+
+1. Computes the diff between desired and actual state
+2. Sends `SUBSCRIBE` commands for channels in desired but not in actual
+3. Sends `UNSUBSCRIBE` commands for channels in actual but not in desired
+4. Processes any pending unsubscribes caused by topology changes (slot migrations, node removals)
+
+This architecture provides several benefits:
+
+* **Cluster-aware resubscription:** If a connection drops, a node fails, or slots migrate, the synchronizer detects the discrepancy and automatically resubscribes on the correct nodes. Subscriptions are tracked per node address, so recovery is targeted rather than global.
+* **Subscription load balancing:** In cluster mode, subscriptions are distributed across nodes using sharded semantics — each subscription is routed to the node that owns its slot. This spreads the PubSub load across the cluster rather than concentrating it on a single node.
+* **Consistent model:** Both static and dynamic subscriptions flow through the same reconciliation logic, so they benefit equally from automatic recovery.
+
+You can inspect the synchronizer's state at any time using `get_subscriptions()`, which returns both the desired and actual subscription maps.
 
 ## Subscribing
 
-Subscribing in GLIDE differs from the canonical RESP3 protocol. To restore subscription state after a topology change or server disconnect, the subscription configuration is immutable and provided during client creation. Thus, while it is possible to use subscription commands such as `SUBSCRIBE`/`PSUBSCRIBE`/`SSUBSCRIBE` via the custom commands interface, using them alongside this model might lead to unpredictable behavior. The subscription configuration is applied to the servers using the following logic:
+All subscriptions — both static and dynamic — are routed to servers using the following logic:
 
-* **Standalone mode:** The subscriptions are applied to a random node, either a primary or one of the replicas.
-* **Cluster mode:** For both Sharded and Non-sharded subscriptions, the Sharded semantics are used; the subscription is applied to the node holding the slot for the subscription's channel/pattern.
+* **Standalone mode:** Subscribe commands are applied to a random node, either a primary or one of the replicas.
+* **Cluster mode:** For both Sharded and Non-sharded subscriptions, the Sharded semantics are used; the subscription is applied to the node holding the slot for the subscription's channel/pattern. This ensures load distribution across all nodes in the cluster.
+
+### Static Subscriptions (Config-Based)
+
+Static subscriptions are defined during client creation as part of the client configuration.
+
+### Dynamic Subscriptions (GLIDE 2.3+)
+
+Dynamic subscriptions allow you to subscribe and unsubscribe at runtime without creating a new client. They come in two variants:
+
+* **Blocking (with timeout):** Waits for server confirmation before returning. Accepts a `timeout_ms` parameter (0 = wait indefinitely).
+* **Non-blocking (lazy):** Updates the client's desired subscription state and returns immediately. The actual subscription happens asynchronously in the background via the synchronizer's reconciliation process.
+
+| Operation | Blocking | Non-blocking (Lazy) |
+|-----------|----------|---------------------|
+| Subscribe to exact channels | `subscribe(channels, timeout_ms)` | `subscribe_lazy(channels)` |
+| Subscribe to patterns | `psubscribe(patterns, timeout_ms)` | `psubscribe_lazy(patterns)` |
+| Subscribe to sharded channels (cluster only) | `ssubscribe(channels, timeout_ms)` | `ssubscribe_lazy(channels)` |
+| Unsubscribe from exact channels | `unsubscribe(channels, timeout_ms)` | `unsubscribe_lazy(channels)` |
+| Unsubscribe from patterns | `punsubscribe(patterns, timeout_ms)` | `punsubscribe_lazy(patterns)` |
+| Unsubscribe from sharded channels (cluster only) | `sunsubscribe(channels, timeout_ms)` | `sunsubscribe_lazy(channels)` |
+
+*NOTE: Method naming varies by language (e.g., `subscribeLazy` in Java/Node.js/Go, `subscribe_lazy` in Python). To unsubscribe from all channels/patterns, pass `None`/`null`/empty or use the constants `ALL_CHANNELS`, `ALL_PATTERNS`, `ALL_SHARDED_CHANNELS`.*
+
+Dynamic subscriptions work with both static and dynamic subscriptions — you can use `unsubscribe` to remove a channel that was originally defined in the static config.
 
 :::tip[Best Practice]
-Due to the implementation of the resubscription logic, it is recommended to use a dedicated client for PubSub subscriptions. That is, the client with subscriptions should not be the same client that issues commands. In case of topology changes, the internal connections might be reestablished to resubscribe to the correct servers.
+GLIDE uses the RESP3 protocol, which allows PubSub subscriptions and regular commands to coexist on the same client without issues. However, for high-throughput PubSub workloads, consider using a dedicated client for subscriptions to reduce latency on regular commands.
 :::
 
 :::note
@@ -47,7 +102,7 @@ There are three methods for receiving messages:
 
 :::caution
 GLIDE Php does not yet support polling/async message retrieval.
-Only callback-based PubSub is available. See [example](#with-callback) above for usage.
+Only callback-based PubSub is available. See the [how-to guide](/how-to/publish-and-subscribe-messages/#dynamic-subscriptions-glide-23) for usage.
 :::
 
 The intended method is selected during client creation with the subscription configuration.
@@ -56,14 +111,30 @@ Calls to the polling/async methods are prohibited and will fail.
 In the case of async/polling, incoming messages will be buffered in an unbounded buffer.
 The user should ensure timely extraction of incoming messages to avoid straining the memory subsystem.
 
+Messages have three kinds based on how they were subscribed:
+* **Message** — from exact channel subscriptions (`SUBSCRIBE`)
+* **PMessage** — from pattern subscriptions (`PSUBSCRIBE`)
+* **SMessage** — from sharded channel subscriptions (`SSUBSCRIBE`, cluster only)
+
 ## Unsubscribing
 
-Since the subscription configuration is immutable and applied upon client creation, the model does not provide methods for unsubscribing during the client's lifetime. Additionally, issuing commands such as `UNSUBSCRIBE`/`PUNSUBSCRIBE`/`SUNSUBSCRIBE` via the custom commands interface may lead to unpredictable behavior. Subscriptions will be removed from servers upon client closure, typically as a result of the client's object destructor. Note that some languages, such as Python, might require an explicit call to a cleanup method, e.g.:
+**Prior to GLIDE 2.3:** The subscription configuration is immutable and applied upon client creation, so no methods for runtime unsubscribing are provided. Additionally, issuing commands such as `UNSUBSCRIBE`/`PUNSUBSCRIBE`/`SUNSUBSCRIBE` via the custom commands interface may lead to unpredictable behavior. Subscriptions are removed from servers upon client closure, typically as a result of the client's object destructor. Note that some languages, such as Python, might require an explicit call to a cleanup method, e.g.:
 
 ```python
 client.close()
 ```
 
+**GLIDE 2.3+:** Use the `unsubscribe` / `punsubscribe` / `sunsubscribe` methods (blocking or lazy variants) described in the [Dynamic Subscriptions](#dynamic-subscriptions-glide-23) section above. To unsubscribe from all channels/patterns of a given type, pass `None`/`null`/empty, or use the provided constants (`ALL_CHANNELS`, `ALL_PATTERNS`, `ALL_SHARDED_CHANNELS`). This works for both statically and dynamically subscribed channels. Remaining subscriptions are still cleaned up on client closure.
+
+Unsubscribe commands are routed as follows:
+
+* **Standalone mode:** Unsubscribe commands (`UNSUBSCRIBE`, `PUNSUBSCRIBE`) are sent to **all nodes**. This is necessary because in environments like ElastiCache, the DNS address may change, making it impossible to know which specific node holds the subscription.
+* **Cluster mode:** Unsubscribe commands are routed to the specific node address where the subscription is tracked. For **sharded** unsubscribes (`SUNSUBSCRIBE`), channels are grouped by slot and each group is sent to the appropriate slot owner.
+
+## Subscription State Introspection (GLIDE 2.3+)
+
+Use `get_subscriptions()` to inspect the current subscription state. It returns both the **desired** subscriptions (what you've requested) and the **actual** subscriptions (what the server has confirmed). This is useful for verifying that dynamic subscriptions have been fully applied, especially when using non-blocking (lazy) operations.
+
 ## What's Next
 
-Take a look at our [guide](/how-to/publish-and-subscribe-messages/) on how to configure pubsub for different clients.
+Take a look at our [Pub/Sub Messaging](/how-to/publish-and-subscribe-messages/) how-to for usage examples across all supported languages.

--- a/src/content/docs/how-to/publish-and-subscribe-messages.mdx
+++ b/src/content/docs/how-to/publish-and-subscribe-messages.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configure Pub/Sub
-description: See how to subscribe and publish messages with Valkey GLIDE clients.
+title: Pub/Sub Messaging
+description: Learn how to publish, subscribe, and manage Pub/Sub with Valkey GLIDE clients.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -8,15 +8,20 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 Valkey GLIDE PubSub aims to unify various nuances into a coherent interface, minimizing differences between Sharded, Cluster, and Standalone configurations.
 Additionally, GLIDE is responsible for tracking topology changes in real time, ensuring the client remains subscribed regardless of any connectivity issues.
 
-This guide will go over how to configure GLIDE pubsub system.
+This guide will go over how to configure GLIDE's PubSub system.
 
-## Use Separate Clients
+## Using Separate Clients
 
-Due to the implementation of the resubscription logic, it is recommended to use a dedicated client for PubSub subscriptions.
-That is, the client with subscriptions should not be the same client that issues commands.
-In case of topology changes, the internal connections might be reestablished to resubscribe to the correct servers.
+GLIDE uses the RESP3 protocol, which allows PubSub subscriptions and regular commands to coexist on the same client without issues.
+However, for high-throughput PubSub workloads, consider using a dedicated client for subscriptions to reduce latency on regular commands.
 
-## Publishing Client
+:::note
+Since GLIDE implements automatic re-connections and re-subscriptions on behalf of the user, there is a possibility of message loss during these activities.
+This is not a GLIDE-specific characteristic; similar effects will occur if the user handles such issues independently.
+Since the RESP protocol does not guarantee strong delivery semantics for PubSub functionality, GLIDE does not introduce additional constraints in this regard.
+:::
+
+## Publishing
 
 To publish a message, create a separate client to your Valkey instance. Both Standalone and Cluster are supported.
 
@@ -81,19 +86,206 @@ To publish a message, create a separate client to your Valkey instance. Both Sta
   </TabItem>
 </Tabs>
 
-:::note
-Since GLIDE implements automatic re-connections and re-subscriptions on behalf of the user, there is a possibility of message loss during these activities.
-This is not a GLIDE-specific characteristic; similar effects will occur if the user handles such issues independently.
-Since the RESP protocol does not guarantee strong delivery semantics for PubSub functionality, GLIDE does not introduce additional constraints in this regard.
-:::
+## Subscribing
 
-## Subscriber Clients
+GLIDE provides two ways to subscribe to channels: **dynamic subscriptions** via API calls at runtime, and **config-based subscriptions** defined at client creation time.
 
-To subscribe to messages, use a separate client with subscriptions configured through the client's configuration object.
+### Dynamic Subscriptions (GLIDE 2.3+)
 
-### With Callback
+Starting with GLIDE 2.3, you can subscribe to channels and patterns at any point during the client's lifetime. Dynamic subscriptions come in two variants:
 
-Glide clients can register a callback method to handle subscriptions in the client configuration.
+* **Blocking:** Waits for server confirmation before returning. Accepts a `timeout_ms` parameter (0 = wait indefinitely).
+* **Non-blocking (lazy):** Updates the desired subscription state and returns immediately. The subscription is applied asynchronously by the background [synchronizer](/concepts/client-features/pubsub-model/#pubsub-synchronizer).
+
+No special configuration is needed at client creation time — you can subscribe dynamically on any client. Messages are buffered and retrievable via polling by default. If you want callback-based delivery instead (explained [below](#callback)), provide a subscription configuration with a callback at client creation time (the initial channel set can be empty).
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Java">
+    ```java
+    // Create a regular client — no subscription configuration needed
+    GlideClientConfiguration config = GlideClientConfiguration.builder()
+            .address(NodeAddress.builder().port(6379).build())
+            .requestTimeout(3000)
+            .build();
+    try (var client = GlideClient.createClient(config).get()) {
+
+        // --- Exact channel subscriptions ---
+
+        // Blocking: waits up to 5000ms for server confirmation
+        client.subscribe(Set.of("news", "updates"), 5000).get();
+
+        // Non-blocking (lazy): returns immediately, subscribes in background
+        client.subscribeLazy(Set.of("alerts")).get();
+
+        // --- Pattern subscriptions ---
+
+        // Blocking
+        client.psubscribe(Set.of("chat*", "event*"), 5000).get();
+
+        // Non-blocking (lazy)
+        client.psubscribeLazy(Set.of("log*")).get();
+
+        // --- Sharded subscriptions (cluster mode only) ---
+        // var clusterClient = GlideClusterClient.createClient(clusterConfig).get();
+        // clusterClient.ssubscribe(Set.of("shard-ch1"), 5000).get();
+        // clusterClient.ssubscribeLazy(Set.of("shard-ch2")).get();
+
+        // Retrieve messages via polling
+        PubSubMessage msg = client.getPubSubMessage().get();
+
+    } // remaining subscriptions cleaned up on close
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    // Create a regular client — no subscription configuration needed
+    const config = {
+        addresses: [{ host: "localhost", port: 6379 }],
+    };
+    const client = await GlideClient.createClient(config);
+
+    // --- Exact channel subscriptions ---
+
+    // Blocking: waits up to 5000ms for server confirmation
+    await client.subscribe(new Set(["news", "updates"]), 5000);
+
+    // Non-blocking (lazy): returns immediately, subscribes in background
+    await client.subscribeLazy(new Set(["alerts"]));
+
+    // --- Pattern subscriptions ---
+
+    // Blocking
+    await client.psubscribe(new Set(["chat*", "event*"]), 5000);
+
+    // Non-blocking (lazy)
+    await client.psubscribeLazy(new Set(["log*"]));
+
+    // --- Sharded subscriptions (cluster mode only) ---
+    // await clusterClient.ssubscribe(new Set(["shard-ch1"]), 5000);
+    // await clusterClient.ssubscribeLazy(new Set(["shard-ch2"]));
+
+    // Retrieve messages via polling
+    const msg = await client.getPubSubMessage();
+
+    await client.close();
+    ```
+  </TabItem>
+
+  <TabItem label="Python">
+    ```py
+    # Create a regular client — no subscription configuration needed
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+    )
+    client = await GlideClient.create(config)
+
+    # --- Exact channel subscriptions ---
+
+    # Blocking: waits up to 5000ms for server confirmation
+    await client.subscribe({"news", "updates"}, timeout_ms=5000)
+
+    # Non-blocking (lazy): returns immediately, subscribes in background
+    await client.subscribe_lazy({"alerts"})
+
+    # --- Pattern subscriptions ---
+
+    # Blocking
+    await client.psubscribe({"chat*", "event*"}, timeout_ms=5000)
+
+    # Non-blocking (lazy)
+    await client.psubscribe_lazy({"log*"})
+
+    # --- Sharded subscriptions (cluster mode only) ---
+    # await cluster_client.ssubscribe({"shard-ch1"}, timeout_ms=5000)
+    # await cluster_client.ssubscribe_lazy({"shard-ch2"})
+
+    # Retrieve messages via polling
+    msg = await client.get_pubsub_message()
+
+    await client.close()
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    ctx := context.Background()
+
+    // Create a regular client — no subscription configuration needed
+    config := NewGlideClientConfiguration().
+        WithAddress(&NodeAddress{})
+    client, _ := NewGlideClient(config)
+    defer client.Close()
+
+    // --- Exact channel subscriptions ---
+
+    // Blocking: waits up to 5000ms for server confirmation
+    err := client.Subscribe(ctx, []string{"news", "updates"}, 5000)
+
+    // Non-blocking (lazy): returns immediately, subscribes in background
+    err = client.SubscribeLazy(ctx, []string{"alerts"})
+
+    // --- Pattern subscriptions ---
+
+    // Blocking
+    err = client.PSubscribe(ctx, []string{"chat*", "event*"}, 5000)
+
+    // Non-blocking (lazy)
+    err = client.PSubscribeLazy(ctx, []string{"log*"})
+
+    // --- Sharded subscriptions (cluster mode only) ---
+    // err = clusterClient.SSubscribe(ctx, []string{"shard-ch1"}, 5000)
+    // err = clusterClient.SSubscribeLazy(ctx, []string{"shard-ch2"})
+
+    // Retrieve messages via polling
+    queue, _ := client.GetQueue()
+    if msg := queue.Pop(); msg != nil {
+        fmt.Printf("Received: %s on %s\n", msg.Message, msg.Channel)
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    ```php
+    // Note: PHP uses the PHPRedis-style API where subscribe() is BLOCKING.
+    // It enters a message loop and the callback fires for each message.
+    // Use separate processes/threads for subscriber and publisher.
+
+    $client = new ValkeyGlide();
+    $client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
+
+    // --- Exact channel subscriptions ---
+    // subscribe() blocks and enters a message loop
+    $client->subscribe(['news', 'updates'], function ($client, $channel, $message) {
+        echo "Received '$message' on '$channel'\n";
+
+        // Unsubscribe from a specific channel
+        if ($message === 'stop') {
+            $client->unsubscribe([$channel]);
+        }
+    });
+    // Code here runs after all channels are unsubscribed
+
+    // --- Pattern subscriptions ---
+    $client->psubscribe(['chat*', 'event*'], function ($client, $channel, $message, $pattern) {
+        echo "[$pattern] $channel: $message\n";
+
+        // Unsubscribe from a specific pattern
+        $client->punsubscribe([$pattern]);
+    });
+
+    // Unsubscribe from all channels/patterns (from within callback):
+    // $client->unsubscribe();      // all exact channels
+    // $client->punsubscribe();     // all patterns
+
+    $client->close();
+    ```
+  </TabItem>
+</Tabs>
+
+### Config-Based Subscriptions (All Versions)
+
+For GLIDE versions prior to 2.3, or when your subscriptions are known at startup, you can define them in the client configuration. These subscriptions are applied immediately when the client connects.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Java">
@@ -200,33 +392,165 @@ Glide clients can register a callback method to handle subscriptions in the clie
   </TabItem>
 
   <TabItem label="PHP">
-    ```php
-    // Note: subscribe() is BLOCKING in PHP - it enters a message loop
-    // Use separate processes/threads for subscriber and publisher
-
-    // Subscriber process:
-    $listeningClient = new ValkeyGlide();
-    $listeningClient->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
-
-    // This call BLOCKS and enters message loop
-    $listeningClient->subscribe(['ch1', 'ch2'], function($client, $channel, $message) {
-        echo "Received $message on channel $channel\n";
-        
-        // To exit the loop, call unsubscribe
-        if ($message === 'exit') {
-            $client->unsubscribe(['ch1', 'ch2']);
-        }
-    });
-
-    // Code here only runs after unsubscribe
-    $listeningClient->close();
-    ```
+    :::note
+    PHP GLIDE does not use config-based subscriptions. It uses the PHPRedis-style API where `subscribe()` and `psubscribe()` are called at runtime. See [Dynamic Subscriptions](#dynamic-subscriptions-glide-23) above.
+    :::
   </TabItem>
 </Tabs>
 
-### Non-Callback
+## Receiving Messages
 
-Alternatively, GLIDE clients also provide options to use the client's native async features to handle polling for messages.
+There are two approaches: **callback-based** (messages are pushed to your function automatically) and **polling-based** (you pull messages when ready). The approach is determined by whether a callback is provided in the subscription configuration.
+
+:::caution
+When a callback is configured, all incoming messages are sent to that callback. Calls to `getPubSubMessage()` / `tryGetPubSubMessage()` are prohibited and will fail. The two modes cannot be mixed.
+:::
+
+### Callback
+
+To use callback-based delivery, provide a subscription configuration with a callback at client creation time. The callback fires for every incoming message — from both config-based and dynamic subscriptions.
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Java">
+    ```java
+    List<String> received = Collections.synchronizedList(new ArrayList<>());
+    MessageCallback callback = (msg, context) -> {
+        received.add(msg.getMessage());
+        System.out.printf("Received '%s' on '%s'\n", msg.getMessage(), msg.getChannel());
+    };
+
+    GlideClientConfiguration config = GlideClientConfiguration.builder()
+            .address(NodeAddress.builder().port(6379).build())
+            .requestTimeout(3000)
+            .subscriptionConfiguration(StandaloneSubscriptionConfiguration.builder()
+                .callback(callback)
+                .build())
+            .build();
+    try (var client = GlideClient.createClient(config).get()) {
+        // Subscribe dynamically — messages are delivered to the callback
+        client.subscribe(Set.of("news"), 5000).get();
+
+        // Publish a message (from another client)
+        publishingClient.publish("Hello!", "news").get();
+        Thread.sleep(500);
+
+        // Verify the callback received the message
+        assert received.contains("Hello!");
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    const received: string[] = [];
+    const callback = (msg: PubSubMsg, context: any) => {
+        received.push(msg.message);
+        console.log(`Received '${msg.message}' on '${msg.channel}'`);
+    };
+
+    const config = {
+        addresses: [{ host: "localhost", port: 6379 }],
+        pubsubSubscriptions: {
+            channelsAndPatterns: {},
+            callback: callback,
+            context: null,
+        },
+    };
+    const client = await GlideClient.createClient(config);
+
+    // Subscribe dynamically — messages are delivered to the callback
+    await client.subscribe(new Set(["news"]), 5000);
+
+    // Publish a message (from another client)
+    await publishingClient.publish("Hello!", "news");
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Verify the callback received the message
+    console.assert(received.includes("Hello!"));
+
+    client.close();
+    ```
+  </TabItem>
+
+  <TabItem label="Python">
+    ```py
+    received = []
+
+    def callback(msg: CoreCommands.PubSubMsg, context: Any):
+        received.append(msg.message)
+        print(f"Received '{msg.message}' on '{msg.channel}'")
+
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+        pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
+            channels_and_patterns={},
+            callback=callback,
+            context=None,
+        ),
+    )
+    client = await GlideClient.create(config)
+
+    # Subscribe dynamically — messages are delivered to the callback
+    await client.subscribe({"news"}, timeout_ms=5000)
+
+    # Publish a message (from another client)
+    await publishing_client.publish("Hello!", "news")
+    await asyncio.sleep(0.5)
+
+    # Verify the callback received the message
+    assert "Hello!" in received
+
+    await client.close()
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    var received []string
+    var mu sync.Mutex
+    callback := func(message *PubSubMessage, context any) {
+        mu.Lock()
+        received = append(received, message.Message)
+        mu.Unlock()
+        fmt.Printf("Received '%s' on '%s'\n", message.Message, message.Channel)
+    }
+
+    sConfig := NewStandaloneSubscriptionConfig().
+        WithCallback(callback, nil)
+    config := NewGlideClientConfiguration().
+        WithAddress(&NodeAddress{}).
+        WithSubscriptionConfig(sConfig)
+    client, _ := NewGlideClient(config)
+    defer client.Close()
+
+    // Subscribe dynamically — messages are delivered to the callback
+    ctx := context.Background()
+    _ = client.Subscribe(ctx, []string{"news"}, 5000)
+
+    // Publish a message (from another client)
+    publisher.Publish("news", "Hello!")
+    time.Sleep(500 * time.Millisecond)
+
+    // Verify the callback received the message
+    mu.Lock()
+    fmt.Println("Received messages:", received)
+    mu.Unlock()
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    :::note
+    PHP GLIDE uses inline callbacks with `subscribe()` / `psubscribe()`. See the [Dynamic Subscriptions](#dynamic-subscriptions-glide-23) examples above.
+    :::
+  </TabItem>
+</Tabs>
+
+### Polling
+
+If no callback is configured, messages are buffered in an unbounded queue. You retrieve them using:
+
+* **Async wait:** `getPubSubMessage()` / `get_pubsub_message()` — blocks until a message is available.
+* **Non-blocking poll:** `tryGetPubSubMessage()` / `try_get_pubsub_message()` — returns the next message or `null`/`None` immediately.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Java">
@@ -356,11 +680,191 @@ Alternatively, GLIDE clients also provide options to use the client's native asy
   <TabItem label="PHP">
     :::caution
     GLIDE PHP does not support polling/async message retrieval.
-    Only callback-based PubSub is available. See [example](#with-callback) above for usage.
+    Only callback-based PubSub is available. See the [PHP dynamic subscriptions example](#dynamic-subscriptions-glide-23) above.
     :::
+  </TabItem>
+</Tabs>
+
+## Unsubscribing (GLIDE 2.3+)
+
+Starting with GLIDE 2.3, you can unsubscribe from channels and patterns at runtime. Like subscribing, unsubscribing comes in blocking and non-blocking (lazy) variants.
+This works for both config-based and dynamically subscribed channels.
+
+To unsubscribe from **all** channels/patterns of a given type, pass `None`/`null`/empty, or use the provided constants: `ALL_CHANNELS`, `ALL_PATTERNS`, `ALL_SHARDED_CHANNELS`.
+
+:::note
+Prior to GLIDE 2.3, runtime unsubscribing is not available. Subscriptions are removed automatically when the client is closed.
+:::
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Java">
+    ```java
+    // Unsubscribe from specific exact channels (blocking)
+    client.unsubscribe(Set.of("news"), 5000).get();
+
+    // Unsubscribe from specific exact channels (lazy)
+    client.unsubscribeLazy(Set.of("alerts")).get();
+
+    // Unsubscribe from all exact channels
+    client.unsubscribe(PubSubBaseCommands.ALL_CHANNELS, 5000).get();
+
+    // Unsubscribe from specific patterns (blocking)
+    client.punsubscribe(Set.of("chat*"), 5000).get();
+
+    // Unsubscribe from specific patterns (lazy)
+    client.punsubscribeLazy(Set.of("log*")).get();
+
+    // Unsubscribe from all patterns
+    client.punsubscribe(PubSubBaseCommands.ALL_PATTERNS, 5000).get();
+
+    // Sharded unsubscribe (cluster mode only)
+    // clusterClient.sunsubscribe(Set.of("shard-ch1"), 5000).get();
+    // clusterClient.sunsubscribeLazy(Set.of("shard-ch2")).get();
+    // clusterClient.sunsubscribe(PubSubClusterCommands.ALL_SHARDED_CHANNELS, 5000).get();
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    // Unsubscribe from specific exact channels (blocking)
+    await client.unsubscribe(new Set(["news"]), 5000);
+
+    // Unsubscribe from specific exact channels (lazy)
+    await client.unsubscribeLazy(new Set(["alerts"]));
+
+    // Unsubscribe from all exact channels
+    await client.unsubscribe(ALL_CHANNELS, 5000);
+
+    // Unsubscribe from specific patterns (blocking)
+    await client.punsubscribe(new Set(["chat*"]), 5000);
+
+    // Unsubscribe from specific patterns (lazy)
+    await client.punsubscribeLazy(new Set(["log*"]));
+
+    // Unsubscribe from all patterns
+    await client.punsubscribe(ALL_PATTERNS, 5000);
+
+    // Sharded unsubscribe (cluster mode only)
+    // await clusterClient.sunsubscribe(new Set(["shard-ch1"]), 5000);
+    // await clusterClient.sunsubscribeLazy(new Set(["shard-ch2"]));
+    // await clusterClient.sunsubscribe(ALL_SHARDED_CHANNELS, 5000);
+    ```
+  </TabItem>
+
+  <TabItem label="Python">
+    ```py
+    # Unsubscribe from specific exact channels (blocking)
+    await client.unsubscribe({"news"}, timeout_ms=5000)
+
+    # Unsubscribe from specific exact channels (lazy)
+    await client.unsubscribe_lazy({"alerts"})
+
+    # Unsubscribe from all exact channels
+    await client.unsubscribe(ALL_CHANNELS, timeout_ms=5000)
+
+    # Unsubscribe from specific patterns (blocking)
+    await client.punsubscribe({"chat*"}, timeout_ms=5000)
+
+    # Unsubscribe from specific patterns (lazy)
+    await client.punsubscribe_lazy({"log*"})
+
+    # Unsubscribe from all patterns
+    await client.punsubscribe(ALL_PATTERNS, timeout_ms=5000)
+
+    # Sharded unsubscribe (cluster mode only)
+    # await cluster_client.sunsubscribe({"shard-ch1"}, timeout_ms=5000)
+    # await cluster_client.sunsubscribe_lazy({"shard-ch2"})
+    # await cluster_client.sunsubscribe(ALL_SHARDED_CHANNELS, timeout_ms=5000)
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    // Unsubscribe from specific exact channels (blocking)
+    err := client.Unsubscribe(ctx, []string{"news"}, 5000)
+
+    // Unsubscribe from specific exact channels (lazy)
+    err = client.UnsubscribeLazy(ctx, []string{"alerts"})
+
+    // Unsubscribe from all exact channels
+    err = client.Unsubscribe(ctx, AllChannels, 5000)
+
+    // Unsubscribe from specific patterns (blocking)
+    err = client.PUnsubscribe(ctx, []string{"chat*"}, 5000)
+
+    // Unsubscribe from specific patterns (lazy)
+    err = client.PUnsubscribeLazy(ctx, []string{"log*"})
+
+    // Unsubscribe from all patterns
+    err = client.PUnsubscribe(ctx, AllPatterns, 5000)
+
+    // Sharded unsubscribe (cluster mode only)
+    // err = clusterClient.SUnsubscribe(ctx, []string{"shard-ch1"}, 5000)
+    // err = clusterClient.SUnsubscribeLazy(ctx, []string{"shard-ch2"})
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    ```php
+    // In PHP, unsubscribe is called from within the subscribe callback.
+
+    $client->subscribe(['ch1', 'ch2', 'ch3'], function ($client, $channel, $message) {
+        // Unsubscribe from a specific channel
+        $client->unsubscribe([$channel]);
+
+        // Or unsubscribe from all exact channels at once
+        // $client->unsubscribe();
+    });
+
+    $client->psubscribe(['chat*', 'log*'], function ($client, $channel, $message, $pattern) {
+        // Unsubscribe from a specific pattern
+        $client->punsubscribe([$pattern]);
+
+        // Or unsubscribe from all patterns at once
+        // $client->punsubscribe();
+    });
+    ```
+  </TabItem>
+</Tabs>
+
+## Subscription State Introspection (GLIDE 2.3+)
+
+Use `get_subscriptions()` to inspect the current subscription state. It returns both the **desired** subscriptions (what you've requested) and the **actual** subscriptions (what the server has confirmed). This is useful for verifying that lazy subscriptions have been fully applied.
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Java">
+    ```java
+    PubSubState state = client.getSubscriptions().get();
+    System.out.println("Desired: " + state.getDesiredSubscriptions());
+    System.out.println("Actual: " + state.getActualSubscriptions());
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    const state = await client.getSubscriptions();
+    console.log("Desired:", state.desiredSubscriptions);
+    console.log("Actual:", state.actualSubscriptions);
+    ```
+  </TabItem>
+
+  <TabItem label="Python">
+    ```py
+    state = await client.get_subscriptions()
+    print(f"Desired: {state.desired_subscriptions}")
+    print(f"Actual: {state.actual_subscriptions}")
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    state, err := client.GetSubscriptions(ctx)
+    fmt.Println("Desired:", state.DesiredSubscriptions)
+    fmt.Println("Actual:", state.ActualSubscriptions)
+    ```
   </TabItem>
 </Tabs>
 
 ## Next Steps
 
-To learn more about GLIDE's PubSub model, see our [explanation](/concepts/client-features/pubsub-model).
+To learn more about GLIDE's PubSub model and the synchronizer architecture, see our [explanation](/concepts/client-features/pubsub-model).

--- a/src/content/docs/tutorials/pubsub/pubsub-basics.mdx
+++ b/src/content/docs/tutorials/pubsub/pubsub-basics.mdx
@@ -88,6 +88,33 @@ Let's build a simple Hello World example that publishes a message to a channel t
 
      We set `callback=None` because we want to manually fetch messages using an async method, rather than having GLIDE call a function for us.
 
+     :::tip[Dynamic Subscriptions (GLIDE 2.3+)]
+     Instead of defining all subscriptions upfront in the config, you can subscribe dynamically at runtime:
+
+     ```python
+         # Create a client with no initial subscriptions
+         config = GlideClientConfiguration(
+             addresses=[NodeAddress("localhost", 6379)],
+             pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
+                 channels_and_patterns={},
+                 callback=None,
+                 context=None,
+             )
+         )
+         client = await GlideClient.create(config)
+
+         # Subscribe at runtime — blocking (waits for server confirmation)
+         await client.subscribe({"ch1", "ch2"}, timeout_ms=5000)
+         await client.psubscribe({"chat*"}, timeout_ms=5000)
+
+         # Or non-blocking (returns immediately, subscribes in the background)
+         await client.subscribe_lazy({"ch1", "ch2"})
+         await client.psubscribe_lazy({"chat*"})
+     ```
+
+     See the [dynamic subscriptions how-to](/how-to/publish-and-subscribe-messages/#dynamic-subscriptions-glide-23) for more details.
+     :::
+
   3. **Configure the Publishing Client**
 
      Next, we configure a separate, regular client just for publishing messages. This client has no special subscription configuration.
@@ -314,6 +341,26 @@ We can do this by providing a **callback function** when configuring the client.
              )
          )
      ```
+
+     :::tip[Dynamic Subscriptions (GLIDE 2.3+)]
+     With callbacks, you can also start with no initial channels and subscribe dynamically:
+
+     ```python
+         config = GlideClientConfiguration(
+             addresses=[NodeAddress("localhost", 6379)],
+             pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
+                 channels_and_patterns={},
+                 callback=my_callback,
+                 context=app_context,
+             )
+         )
+         client = await GlideClient.create(config)
+         await client.subscribe({"ch1", "ch2"}, timeout_ms=5000)
+         await client.psubscribe({"chat*"}, timeout_ms=5000)
+     ```
+
+     Messages from dynamically subscribed channels are delivered to the same callback.
+     :::
 
   3. **Run the Application**
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE Documentation!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

merging blocked by -

- [x] Merging node dynamic pubsub: https://github.com/valkey-io/valkey-glide/pull/5295
- [x] Completing fixups for Go dynamic pubsub: https://github.com/valkey-io/valkey-glide/pull/5534, https://github.com/valkey-io/valkey-glide/issues/5535
- [x] version 2.3 release.

This PR restructures the existing pubsub sections and adds dynamic pubsub docs and snippets.
For now I didn't include csharp as I saw it's lacking from the entire site, even though it does have a dynamic pubsub impl.


### Issue link

https://github.com/valkey-io/valkey-glide/issues/5544

### Content Changes

- Added elaboration on the new pubsub model
- Added and updated the how-to snippets (and tested them)
- updated the pubsub tutorial

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] All commits are signed off with `--signoff` flag.
- [ ] `pnpm build` runs successfully.
- [ ] Links have been checked for validity.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
