### PR TITLE
Fixed formatter issues escaping square brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "preview": "astro preview",
     "astro": "astro",
     "format:non-mdx": "prettier --write .",
-    "format:mdx": "remark --output --frail \"src/content/docs/**/*.{md,mdx}\"; bash scripts/fix-remark-escapes.sh",
+    "format:mdx": "remark --output \"src/content/docs/**/*.{md,mdx}\"; bash scripts/fix-remark-escapes.sh",
     "format": "pnpm run format:non-mdx && pnpm run format:mdx",
     "format:check:non-mdx": "prettier --check .",
-    "format:check:mdx": "remark --frail --no-stdout \"src/content/docs/**/*.{md,mdx}\"",
+    "format:check:mdx": "remark --no-stdout \"src/content/docs/**/*.{md,mdx}\"",
     "format:check": "pnpm run format:check:non-mdx && pnpm run format:check:mdx",
     "test-deploy": "pnpm build && ./test-deploy.sh"
   },

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "preview": "astro preview",
     "astro": "astro",
     "format:non-mdx": "prettier --write .",
-    "format:mdx": "remark \"src/content/docs/**/*.{md,mdx}\" --output --frail && bash scripts/fix-remark-escapes.sh",
+    "format:mdx": "remark \"src/content/docs/**/*.{md,mdx}\" --output --frail; bash scripts/fix-remark-escapes.sh",
     "format": "pnpm run format:non-mdx && pnpm run format:mdx",
     "format:check:non-mdx": "prettier --check .",
-    "format:check:mdx": "remark --no-stdout \"src/content/docs/**/*.{md,mdx}\"",
+    "format:check:mdx": "bash scripts/check-format.sh",
     "format:check": "pnpm run format:check:non-mdx && pnpm run format:check:mdx",
     "test-deploy": "pnpm build && ./test-deploy.sh"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "format:non-mdx": "prettier --write .",
-    "format:mdx": "remark --output \"src/content/docs/**/*.{md,mdx}\"; bash scripts/fix-remark-escapes.sh",
+    "format:mdx": "remark \"src/content/docs/**/*.{md,mdx}\" --output --frail && bash scripts/fix-remark-escapes.sh",
     "format": "pnpm run format:non-mdx && pnpm run format:mdx",
     "format:check:non-mdx": "prettier --check .",
     "format:check:mdx": "remark --no-stdout \"src/content/docs/**/*.{md,mdx}\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "format:non-mdx": "prettier --write .",
-    "format:mdx": "remark --output --frail \"src/content/docs/**/*.{md,mdx}\"",
+    "format:mdx": "remark --output --frail \"src/content/docs/**/*.{md,mdx}\"; bash scripts/fix-remark-escapes.sh",
     "format": "pnpm run format:non-mdx && pnpm run format:mdx",
     "format:check:non-mdx": "prettier --check .",
     "format:check:mdx": "remark --frail --no-stdout \"src/content/docs/**/*.{md,mdx}\"",

--- a/project-docs/structure.md
+++ b/project-docs/structure.md
@@ -335,7 +335,7 @@ _All code examples in the shared documentation will remain language specific wit
 **Global Navigation:**
 
 - Persistent language selector (stored in localStorage)
-- "See this in \[Language]" links in shared content
+- "See this in [Language]" links in shared content
 - Breadcrumb navigation showing shared → specific context
 - Quick-switch between equivalent pages
 

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Run remark check and filter out known false positives (MDX bracket syntax warnings).
+# Fails if any real warnings remain.
+#
+# remark-mdx does not fully understand Starlight's custom directives (e.g. Aside, Tabs),
+# causing false "no-undefined-references" warnings for bracket syntax like [!NOTE].
+# This script will run remark and filter out those specific warnings, while still catching any other real warnings.
+
+cd "$(dirname "$0")/.." || exit 1
+
+output=$(npx remark --no-stdout "src/content/docs/**/*.{md,mdx}" 2>&1)
+remark_exit=$?
+
+if [ $remark_exit -ne 0 ]; then
+  echo "$output"
+  echo ""
+  echo "❌ FAIL: Remark exited with error code $remark_exit"
+  exit 1
+fi
+
+filtered=$(echo "$output" | grep -v 'for a link or escaped opening bracket' | sed '$d')
+
+echo "$filtered"
+
+warnings=$(echo "$filtered" | grep 'warning')
+
+if [ -n "$warnings" ]; then
+  echo ""
+  echo "❌ FAIL: Remark lint found warnings"
+  exit 1
+fi
+
+echo ""
+echo "✅ PASS: No remark lint warnings found"

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run remark check and filter out known false positives (MDX bracket syntax warnings).
 # Fails if any real warnings remain.
@@ -19,17 +19,27 @@ if [ $remark_exit -ne 0 ]; then
   exit 1
 fi
 
-filtered=$(echo "$output" | grep -v 'for a link or escaped opening bracket' | sed '$d')
-
-echo "$filtered"
-
-warnings=$(echo "$filtered" | grep 'warning')
-
-if [ -n "$warnings" ]; then
+# If the last line ends with ": no issues found" then there's no warnings reported.
+if echo "$output" | tail -1 | grep -q ': no issues found$'; then
+  echo "$output"
   echo ""
-  echo "❌ FAIL: Remark lint found warnings"
+  echo "✅ PASS: No warnings found"
+  exit 0
+fi
+
+ansi_color_stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
+
+# Filtering out expected warnings related to MDX bracket syntax in Starlight's aside shorthand syntax.
+filtered=$(echo "$ansi_color_stripped" | grep -v '^[0-9]*:[0-9]*-[0-9]*:[0-9]* *warning Unexpected reference to undefined definition, expected corresponding definition (`.*`) for a link or escaped opening bracket (`\\\\*\[`) for regular text *no-undefined-references *remark-lint$')
+
+unexpected_warnings=$(echo "$filtered" | grep '^[0-9]*:[0-9]*-[0-9]*:[0-9]* *warning .*')
+
+if [ -n "$unexpected_warnings" ]; then
+  echo "$output"
+  echo ""
+  echo "❌ FAIL: Remark lint found unexpected warnings"
   exit 1
 fi
 
 echo ""
-echo "✅ PASS: No remark lint warnings found"
+echo "✅ PASS: No unexpected warnings found"

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -29,7 +29,7 @@ fi
 
 ansi_color_stripped=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g')
 
-# Filtering out expected warnings related to MDX bracket syntax in Starlight's aside shorthand syntax.
+# Filtering out expected warnings; These warnings are bracket syntax warnings as a result of Starlight's aside shorthand syntax.
 filtered=$(echo "$ansi_color_stripped" | grep -v '^[0-9]*:[0-9]*-[0-9]*:[0-9]* *warning Unexpected reference to undefined definition, expected corresponding definition (`.*`) for a link or escaped opening bracket (`\\\\*\[`) for regular text *no-undefined-references *remark-lint$')
 
 unexpected_warnings=$(echo "$filtered" | grep '^[0-9]*:[0-9]*-[0-9]*:[0-9]* *warning .*')

--- a/scripts/fix-remark-escapes.sh
+++ b/scripts/fix-remark-escapes.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Fixes remark-stringify escaping [ to \[ in:
+# 1. Starlight directives: :::type\[Title] → :::type[Title]
+# 2. Checkbox list items: * \[ ] → * [ ]
+find src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) -print0 | \
+  xargs -0 sed -i '' \
+    -e 's/:::\([a-z]*\)\\\[/:::\1[/g' \
+    -e 's/^\( *\)\* \\\[ ]/\1* [ ]/g' \
+    -e 's/^\( *\)- \\\[ ]/\1- [ ]/g'

--- a/scripts/fix-remark-escapes.sh
+++ b/scripts/fix-remark-escapes.sh
@@ -3,7 +3,8 @@
 # 1. Starlight directives: :::type\[Title] → :::type[Title]
 # 2. Checkbox list items: * \[ ] → * [ ]
 find src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) -print0 | \
-  xargs -0 sed -i '' \
+  xargs -0 sed -i.bak \
     -e 's/:::\([a-z]*\)\\\[/:::\1[/g' \
     -e 's/^\( *\)\* \\\[ ]/\1* [ ]/g' \
     -e 's/^\( *\)- \\\[ ]/\1- [ ]/g'
+find src/content/docs -type f -name '*.bak' -delete

--- a/src/content/docs/concepts/architecture/async-execution.mdx
+++ b/src/content/docs/concepts/architecture/async-execution.mdx
@@ -17,7 +17,7 @@ When combined with Valkey's [pipelining](https://valkey.io/topics/pipelining/) c
 send off requests without waiting for responses using a single multiplex connection.
 This design allows GLIDE clients to deliver high asynchronous performance with only a single connection.
 
-:::tip\[Using a Single Client]
+:::tip[Using a Single Client]
 Using a single client instance (a single connection) is the best way to ensure high performance.
 However, in some scenarios, opening connections for separate tasks can be more beneficial.
 
@@ -66,7 +66,7 @@ To achieve this, each of GLIDE's clients supports the language's native asynchro
     }()
     ```
 
-    :::note\[Goroutines Compatible]
+    :::note[Goroutines Compatible]
     The GLIDE Go client is thread safe and compatible with goroutines.
     :::
   </TabItem>
@@ -77,7 +77,7 @@ To achieve this, each of GLIDE's clients supports the language's native asynchro
     $client->set('user:101', 'active');
     ```
 
-    :::note\[Synchronous API]
+    :::note[Synchronous API]
     The GLIDE PHP client uses a synchronous blocking API, similar to PHPRedis. While operations block until completion, the underlying Rust core still uses connection multiplexing for efficient communication with Valkey.
     :::
   </TabItem>

--- a/src/content/docs/concepts/client-features/pubsub-model.mdx
+++ b/src/content/docs/concepts/client-features/pubsub-model.mdx
@@ -11,7 +11,7 @@ GLIDE is also responsible for tracking topology changes in real time, ensuring t
 
 Conceptually, the PubSub functionality can be divided into four actions: Subscribing, Publishing, Receiving, and Unsubscribing.
 
-:::note\[PHP PubSub Model]
+:::note[PHP PubSub Model]
 PHP GLIDE uses a different PubSub model based on the PHPRedis API. Instead of immutable subscription configuration during client creation, PHP uses traditional method calls like `subscribe()`, `psubscribe()`, `publish()`, and `unsubscribe()` with callback functions.
 :::
 
@@ -22,7 +22,7 @@ Subscribing in GLIDE differs from the canonical RESP3 protocol. To restore subsc
 * **Standalone mode:** The subscriptions are applied to a random node, either a primary or one of the replicas.
 * **Cluster mode:** For both Sharded and Non-sharded subscriptions, the Sharded semantics are used; the subscription is applied to the node holding the slot for the subscription's channel/pattern.
 
-:::tip\[Best Practice]
+:::tip[Best Practice]
 Due to the implementation of the resubscription logic, it is recommended to use a dedicated client for PubSub subscriptions. That is, the client with subscriptions should not be the same client that issues commands. In case of topology changes, the internal connections might be reestablished to resubscribe to the correct servers.
 :::
 

--- a/src/content/docs/concepts/client-features/valkey-scripting.mdx
+++ b/src/content/docs/concepts/client-features/valkey-scripting.mdx
@@ -10,14 +10,14 @@ custom logic directly on the server. This page will explain how GLIDE handles Va
 
 For more detail on just Valkey scripting, visit the Valkey [documentation](https://valkey.io/topics/eval-intro/).
 
-:::tip\[Valkey Functions]
+:::tip[Valkey Functions]
 GLIDE also support Valkey Functions, an alternative approach scripting. To see how to use Valkey Functions
 with GLIDE, see our [guide](/how-to/load-and-execute-functions/).
 
 To learn more about Valkey Functions, see the Valkey [documentations](https://valkey.io/topics/functions-intro/).
 :::
 
-:::caution\[Php Not Supported]
+:::caution[Php Not Supported]
 The GLIDE Php client does not yet support this interface.
 To execute custom scripts, use the appropriate Php Valkey command API for executing and caching scripts.
 :::
@@ -253,7 +253,7 @@ values directly into the script would create unique scripts each time, preventin
   </TabItem>
 </Tabs>
 
-:::tip\[Large Data]
+:::tip[Large Data]
 GLIDE can handle large `KEYS` and `ARGV` inputs efficiently.
 :::
 
@@ -332,7 +332,7 @@ Scripts with identical code produce identical hashes, enabling efficient caching
   </TabItem>
 </Tabs>
 
-:::caution\[Script hashing is content-sensitive]
+:::caution[Script hashing is content-sensitive]
 Script hashes are based on the entire script content, including spaces, line breaks, and all characters.
 Ensure you load the exact same script to benefit from caching.
 :::
@@ -344,7 +344,7 @@ Scripts remain cached on the Valkey server until:
 * You explicitly flush the cache with `script_flush()`
   All of which are handled automatically by GLIDE.
 
-:::tip\[Ephemeral Scripts]
+:::tip[Ephemeral Scripts]
 Valkey scripts are not guaranteed to be persisted. It is the responsibility of the client to manage the scripts used.
 :::
 

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -165,7 +165,7 @@ Windows support is currently available only for Valkey-GLIDE Java
   </TabItem>
 </ParamTabs>
 
-:::tip\[Installation Guides]
+:::tip[Installation Guides]
 For more detailed instructions, refer to our installation [guides](/how-to/installation).
 :::
 

--- a/src/content/docs/how-to/execute-custom-scripts.mdx
+++ b/src/content/docs/how-to/execute-custom-scripts.mdx
@@ -339,7 +339,7 @@ The following steps shows how to run a simple a custom Lua script using GLIDE.
          ```
     </Steps>
 
-    :::tip\[Script API vs eval/evalSha]
+    :::tip[Script API vs eval/evalSha]
     Other GLIDE clients provide a `Script` API that automatically handles script caching and SHA1 management. In PHP, you manually manage this using `eval()` and `evalsha()`. For detailed patterns and best practices, see the [Valkey Scripting Reference](/reference/scripting-reference).
     :::
   </TabItem>

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -134,7 +134,7 @@ Windows support is currently available only for Valkey-GLIDE Java
 
     To get started, add one of the following snippet into the build file for your tool.
 
-    :::caution\[Include Classifiers]
+    :::caution[Include Classifiers]
     You must include the classifier for your OS. It is recommended to use the [OS Detector](https://github.com/google/osdetector-gradle-plugin) plugin to
     detect the correct classifier for your OS.
 

--- a/src/content/docs/how-to/monitoring/open-telemetry.mdx
+++ b/src/content/docs/how-to/monitoring/open-telemetry.mdx
@@ -182,6 +182,6 @@ If using `file://` as the endpoint:
 * File exporter paths must start with `file://` and have an existing parent directory.
 * Invalid configuration will throw an error synchronously when calling initialization.
 
-:::caution\[Important]
+:::caution[Important]
 `OpenTelemetry.init()` can only be called **once per process**. Subsequent calls will be ignored. To change configuration, restart the process.
 :::

--- a/src/content/docs/how-to/monitoring/tracking-resources.mdx
+++ b/src/content/docs/how-to/monitoring/tracking-resources.mdx
@@ -10,7 +10,7 @@ GLIDE 1.2 introduces a new non-Valkey API: `getStatistics` which returns statist
 * `total_connections` contains the number of active connections across **all** clients
 * `total_clients` contains the number of active clients (regardless of its type)
 
-:::caution\[Not Generally Available]
+:::caution[Not Generally Available]
 This is not supported by the Go client.
 :::
 

--- a/src/content/docs/how-to/security/dynamic-authentication.mdx
+++ b/src/content/docs/how-to/security/dynamic-authentication.mdx
@@ -185,11 +185,11 @@ Below are examples demonstrating how to utilize the dynamic password update feat
 To avoid authentication errors, update the client's password immediately after any server-side password changes.
 :::
 
-:::tip\[Remove Password]
+:::tip[Remove Password]
 In case you want to remove the password from the connection configuration, you can pass `null`/`None` as the password.
 :::
 
-:::caution\[ACL Permissions]
+:::caution[ACL Permissions]
 When dynamically switching to a new credential, ensure that it has enough permissions to run connection startup commands. See the [ACL Permissions Requirements](/reference/access-control) for more details.
 :::
 

--- a/src/content/docs/how-to/security/iam-integration-using-aws-sdk.mdx
+++ b/src/content/docs/how-to/security/iam-integration-using-aws-sdk.mdx
@@ -5,7 +5,7 @@ description: Guide for integrating Valkey GLIDE with AWS IAM using AWS SDK for s
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-:::note\[Built-in IAM Support in GLIDE 2.2+]
+:::note[Built-in IAM Support in GLIDE 2.2+]
 Starting with GLIDE 2.2+, built-in support for **AWS Identity and Access Management (IAM)** authentication is available when connecting to Amazon ElastiCache and MemoryDB clusters.
 This feature automatically handles token generation and rotation, making it simple to maintain secure connections.
 
@@ -79,7 +79,7 @@ Please refer to the [AWS SDK docs](https://docs.aws.amazon.com/AmazonElastiCache
   </TabItem>
 
   <TabItem label="Java">
-    :::note\[AWS SDK v2]
+    :::note[AWS SDK v2]
     This token generation example uses AWS SDK for Java v2. For token generation using AWS SDK for Java v1, see the Legacy section below.
     :::
 
@@ -225,7 +225,7 @@ Please refer to the [AWS SDK docs](https://docs.aws.amazon.com/AmazonElastiCache
   </TabItem>
 
   <TabItem label="PHP">
-    :::note\[Use Built-in IAM Support]
+    :::note[Use Built-in IAM Support]
     PHP users should use the built-in IAM authentication support available in GLIDE 2.2+.
 
     See the [IAM Authentication with GLIDE](/how-to/security/iam-integration) guide for PHP examples using the native IAM integration.
@@ -396,7 +396,7 @@ Please refer to the [AWS SDK docs](https://docs.aws.amazon.com/AmazonElastiCache
   </TabItem>
 
   <TabItem label="PHP">
-    :::note\[Use Built-in IAM Support]
+    :::note[Use Built-in IAM Support]
     PHP users should use the built-in IAM authentication support available in GLIDE 2.2+.
 
     See the [IAM Authentication with GLIDE](/how-to/security/iam-integration) guide for PHP examples using the native IAM integration.
@@ -585,7 +585,7 @@ This capability is required when performing IAM authentication with AWS SDK beca
 
 To efficiently manage this, GLIDE provides the ability to update short-lived tokens using `updateConnectionPassword` (or `update_connection_password`) to periodically refresh the token without immediately re-authenticating. It also offers the option for immediate re-authentication using `immediateAuth` (or `immediate_auth`), which forces re-authentication and extends the connection for another 12 hours.
 
-:::tip\[Best Practices]
+:::tip[Best Practices]
 
 * Refresh the IAM token every 10 minutes using `updateConnectionPassword` without triggering immediate re-authentication.
 * Perform an immediate re-authentication every 10 hours to prolong the connection for another 12-hour window.

--- a/src/content/docs/how-to/security/iam-integration.mdx
+++ b/src/content/docs/how-to/security/iam-integration.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 GLIDE 2.2+ provides built-in support for **AWS Identity and Access Management (IAM)** authentication when connecting to **Amazon ElastiCache** and **MemoryDB** clusters. This feature automatically handles token generation and rotation, making it simple to maintain secure connections.
 
-:::caution\[GLIDE 2.2+ Required]
+:::caution[GLIDE 2.2+ Required]
 For GLIDE versions below 2.2, see the [guide](/how-to/security/iam-integration-using-aws-sdk) on how to configure IAM authentication using the AWS SDK.
 :::
 

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -407,19 +407,19 @@ The `TlsAdvancedConfiguration` object provides advanced TLS settings for both st
   </TabItem>
 
   <TabItem label="Java">
-    :::note\[Coming soon]
+    :::note[Coming soon]
     Advanced TLS configuration documentation for Java is coming soon.
     :::
   </TabItem>
 
   <TabItem label="Node">
-    :::note\[Coming soon]
+    :::note[Coming soon]
     Advanced TLS configuration documentation for Node.js is coming soon.
     :::
   </TabItem>
 
   <TabItem label="Go">
-    :::note\[Coming soon]
+    :::note[Coming soon]
     Advanced TLS configuration documentation for Go is coming soon.
     :::
   </TabItem>

--- a/src/content/docs/how-to/send-batch-commands.mdx
+++ b/src/content/docs/how-to/send-batch-commands.mdx
@@ -377,7 +377,7 @@ A transaction is an all-or-nothing set of commands sent in a single request to V
   </TabItem>
 </Tabs>
 
-:::caution\[Important]
+:::caution[Important]
 If you attempt to include keys from different slots, the batch creation will throw an exception informing you that keys must map to the same slot when `isAtomic = true`.
 :::
 

--- a/src/content/docs/how-to/synchronous-connection.mdx
+++ b/src/content/docs/how-to/synchronous-connection.mdx
@@ -5,7 +5,7 @@ description: Use the synchronous Python client for Valkey GLIDE with blocking op
 
 import { Badge, TabItem, Tabs } from '@astrojs/starlight/components';
 
-:::caution\[Python Only!]
+:::caution[Python Only!]
 The synchronous client is Python only. Support for other languages may be added in the future.
 :::
 

--- a/src/content/docs/migration/java/jedis/jedis-compatibility-layer/instructions.mdx
+++ b/src/content/docs/migration/java/jedis/jedis-compatibility-layer/instructions.mdx
@@ -73,7 +73,7 @@ After migration, it is crucial to throughly evaluate your application to ensure 
 3. Consider using Valkey GLIDE to support unsupported features.
 4. Monitor performance and behavior differences.
 
-:::tip\[Have a Rollback Plan]
+:::tip[Have a Rollback Plan]
 Be prepared to revert to your original Jedis dependency if you discover critical incompatibilities.
 :::
 

--- a/src/content/docs/migration/php/phpredis/index.mdx
+++ b/src/content/docs/migration/php/phpredis/index.mdx
@@ -501,17 +501,17 @@ Valkey GLIDE PHP supports all major Redis/Valkey features including:
 
 ## Migration Checklist
 
-* \[ ] Update installation method to use PIE, Composer, or PECL
-* \[ ] Optional: Call `ValkeyGlide::registerPHPRedisAliases()` for drop-in compatibility (PHP 8.3+)
-* \[ ] Update connection code to use two-step pattern (construct then connect)
-* \[ ] Update array parameters for push/set operations (lpush, rpush, sadd, srem)
-* \[ ] Add exception handling around connection operations
-* \[ ] Update return type expectations for consistency
-* \[ ] Test cluster operations if using cluster mode
-* \[ ] Update configuration to use `connect()` method parameters
-* \[ ] Verify TLS/SSL configuration if using encrypted connections
-* \[ ] Test IAM authentication if using AWS ElastiCache
-* \[ ] Performance test to validate improvements
+* [ ] Update installation method to use PIE, Composer, or PECL
+* [ ] Optional: Call `ValkeyGlide::registerPHPRedisAliases()` for drop-in compatibility (PHP 8.3+)
+* [ ] Update connection code to use two-step pattern (construct then connect)
+* [ ] Update array parameters for push/set operations (lpush, rpush, sadd, srem)
+* [ ] Add exception handling around connection operations
+* [ ] Update return type expectations for consistency
+* [ ] Test cluster operations if using cluster mode
+* [ ] Update configuration to use `connect()` method parameters
+* [ ] Verify TLS/SSL configuration if using encrypted connections
+* [ ] Test IAM authentication if using AWS ElastiCache
+* [ ] Performance test to validate improvements
 
 ## Performance Benefits
 

--- a/src/content/docs/reference/access-control.mdx
+++ b/src/content/docs/reference/access-control.mdx
@@ -8,7 +8,7 @@ Valkey/Redis-OSS supports authentication mechanisms, enabling secure connections
 * **Password Authentication**: Clients authenticate using a predefined password.
 * **Access Control Lists (ACLs)**: Offers granular user permissions with individual passwords.
 
-:::tip\[ACLs Overview]
+:::tip[ACLs Overview]
 ACLs provide extensive control over permissions. For detailed insights, please visit the [Valkey ACL documentation](https://valkey.io/topics/acl/).
 :::
 

--- a/src/content/docs/reference/scripting-reference.mdx
+++ b/src/content/docs/reference/scripting-reference.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 This page contains code references for working with custom Lua scripts in Valkey GLIDE.
 
-:::caution\[PHP Not Supported]
+:::caution[PHP Not Supported]
 The GLIDE PHP client does not support the `Script` interface or `invokeScript()` method.
 To execute custom scripts, use the PHP Valkey command API methods: `eval()`, `evalsha()`, `eval_ro()`, and `evalsha_ro()`.
 :::
@@ -731,7 +731,7 @@ end
 
 ### Script Timeout Handling
 
-:::caution\[Client Timeout vs Script Termination]
+:::caution[Client Timeout vs Script Termination]
 When a client timeout occurs, the client stops waiting for a response, but the script continues running on the server. To stop a read-only script that's still executing, use `SCRIPT KILL`.
 :::
 

--- a/src/content/docs/tutorials/lua-scripting/custom-atomic-ops.mdx
+++ b/src/content/docs/tutorials/lua-scripting/custom-atomic-ops.mdx
@@ -126,12 +126,12 @@ To handle errors, use [`server.pcall()`](https://valkey.io/topics/lua-api/#serve
 
 Keys and inputs are passed into `KEYS` and `ARGV` parameters in our scripts which we will cover in the next section.
 
-:::tip\[Keep It Light]
+:::tip[Keep It Light]
 Valkey ensures atomicity by blocking all actions on a node until Lua script finishes.
 Be sure to keep your scripts small and avoid long-running operations.
 :::
 
-:::tip\[Lua Scripting API]
+:::tip[Lua Scripting API]
 For more on the available methods for use in Lua scripts, see the documentation on [Lua API](https://valkey.io/topics/lua-api/).
 :::
 
@@ -168,7 +168,7 @@ Valkey uses declared `KEYS` to locate the correct node (in both standalone and c
 GLIDE caches `Script()` server-side using content hashes to reduce overhead. Always use ARGV for variable inputs.
 Hardcoding values generates unique hashes for otherwise identical scripts, which defeats caching and can exhaust host memory.
 
-:::caution\[Script Hashing]
+:::caution[Script Hashing]
 Script hashes are based on the entire script content. This includes spaces, line breaks, and all characters.
 Always ensure you are loading the exact same scripts.
 :::

--- a/src/content/docs/tutorials/pubsub/notification.mdx
+++ b/src/content/docs/tutorials/pubsub/notification.mdx
@@ -35,7 +35,7 @@ You'll need the following:
 The example will have two scripts, a `listener.py` that listens for messages from `producer.py`.
 Place them in the same folder as the `docker-compose.yml`.
 
-:::tip\[Use Dedicated Clients]
+:::tip[Use Dedicated Clients]
 It is a best practice to use **dedicated instances for your subscriptions**.
 Your application will have one client for listening (the subscriber) and another for all other commands, including publishing.
 :::

--- a/src/content/docs/tutorials/pubsub/pubsub-basics.mdx
+++ b/src/content/docs/tutorials/pubsub/pubsub-basics.mdx
@@ -131,7 +131,7 @@ Let's build a simple Hello World example that publishes a message to a channel t
                  print("Publishing client closed.")
      ```
 
-     :::caution\[Use Dedicated Subscriber Clients]
+     :::caution[Use Dedicated Subscriber Clients]
      Separate clients for publishing and subscribing should be used.
      A client in subscription mode is only focused on listening and cannot run other commands.
      :::

--- a/src/content/docs/tutorials/tls.mdx
+++ b/src/content/docs/tutorials/tls.mdx
@@ -5,7 +5,7 @@ description: A reference page in my new Starlight docs site.
 
 import { Steps } from '@astrojs/starlight/components';
 
-:::caution\[Work In Progress!]
+:::caution[Work In Progress!]
 This documentation site is under construction and is not yet complete!
 
 For official Valkey GLIDE documentation, please refer to the official [Valkey GLIDE](https://github.com/valkey-io/valkey-glide) GitHub.


### PR DESCRIPTION
### Summary

This PR fixed the issue with the current formatter escaping `[`. In particular:

It is escaping the aside shorthand syntax.
```
:::tip[My aside's title]
Aside's contents
:::
```

Would be escaped to
```
:::tip\[My aside's title]
Aside's contents
:::
```

It is also escaping checkboxes brackets:
```
* \[ ] checkbox content
```

### Content Changes

- Updated `package.json` with new `format` command.
- Added `scripts/fix-remark-escapes.sh` which runs after format to fix the escaped brackets.
- Added `scripts/check-format.sh`: The script is used to check for formatting error that are not the result of remark not understanding aside syntax.
- Apply the new formating across the repo.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] All commits are signed off with `--signoff` flag.
- [ ] `pnpm build` runs successfully.
- [ ] Links have been checked for validity.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
