### PR TITLE
Java: Add uber jar installation option for Valkey GLIDE

### DIFF
--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -82,14 +82,16 @@ Windows support is currently available only for Valkey-GLIDE Java
 
     Add the following to your build tool. Make sure to specify your classifier for your OS.
 
+    :::tip[Uber Jar Available]
+    Starting from version 2.3.0, Java users can choose between the uber jar (no classifier needed) or a platform-specific jar with a classifier.
+    The uber jar bundles all platform binaries, so it is larger in size. If you prefer a smaller dependency, use the classifier-based jar for your specific OS.
+    :::
+
     <Tabs>
       <TabItem label="Gradle">
         ```groovy
-        plugins {
-            id "com.google.osdetector" version "1.7.3"
-        }
         dependencies {
-            implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+            implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+'
         }
         ```
       </TabItem>

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -28,6 +28,13 @@ export const mavenExample =
     </dependency>
 </dependencies>
 
+<!-- uber jar -->
+<dependency>
+    <groupId>io.valkey</groupId>
+    <artifactId>valkey-glide</artifactId>
+    <version>${javaGlideLatest}</version>
+</dependency>
+
 <!-- osx-x86_64 -->
 <dependency>
     <groupId>io.valkey</groupId>
@@ -134,14 +141,18 @@ Windows support is currently available only for Valkey-GLIDE Java
 
     To get started, add one of the following snippet into the build file for your tool.
 
-    :::caution[Include Classifiers]
-    You must include the classifier for your OS. It is recommended to use the [OS Detector](https://github.com/google/osdetector-gradle-plugin) plugin to
-    detect the correct classifier for your OS.
+    :::tip[Uber Jar vs Classifier]
+    Starting from version 2.3.0, you can use the uber jar (no classifier needed), which bundles all platform binaries.
+    The uber jar is larger in size. If you prefer a smaller dependency, use a platform-specific classifier for your OS.
 
-    Otherwise, the following specifiers are supported:
+    For versions lower than 2.3.0. It is recommended to use the [OS Detector](https://github.com/google/osdetector-gradle-plugin) plugin to
+    automatically detect the correct classifier.
+
+    The following classifiers are supported:
 
     ```
     osx-x86_64
+    osx-aarch_64
     linux-aarch_64
     linux-x86_64
     linux_musl-aarch_64
@@ -162,6 +173,15 @@ Windows support is currently available only for Valkey-GLIDE Java
         }
         dependencies {
             implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+        }
+        ```
+
+        Example with uber jar:
+
+        ```groovy
+        // with osdetector
+        dependencies {
+            implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+'
         }
         ```
 
@@ -217,6 +237,10 @@ Windows support is currently available only for Valkey-GLIDE Java
 
       <TabItem label="SBT">
         ```scala
+
+        // uber jar
+        libraryDependencies += "io.valkey" % "valkey-glide" % "2.+"
+
         // osx-aarch_64
         libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "osx-aarch_64"
 

--- a/src/content/docs/migration/java/jedis/manual-migrations/Installation.mdx
+++ b/src/content/docs/migration/java/jedis/manual-migrations/Installation.mdx
@@ -25,8 +25,12 @@ Add the following dependency to your `pom.xml` file:
 
 ## Full Installations
 
-To use Valkey GLIDE, you must include a classifier to specify your platform architecture.\
 This section includes setup instructions for Gradle, Maven, and SBT, with or without OS detection tools.
+
+:::tip[Uber Jar vs Classifier]
+Starting from version 2.3.0, you can use the uber jar (no classifier needed), which bundles all platform binaries.
+The uber jar is larger in size. If you prefer a smaller dependency, use a platform-specific classifier for your OS.
+:::
 
 <Tabs>
   <TabItem label="Gradle">
@@ -41,6 +45,15 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with uber jar:
+
+    ```groovy
+    // with uber jar
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+'
     }
     ```
 
@@ -102,6 +115,14 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     <Code
       lang="xml"
       code={`
+
+<!--uber jar-->
+<dependency>
+<groupId>io.valkey</groupId>
+<artifactId>valkey-glide</artifactId>
+<version>${javaGlideLatest}</version>
+</dependency>
+
 <!--osx-aarch_64-->
 <dependency>
 <groupId>io.valkey</groupId>
@@ -152,6 +173,9 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     </Aside>
 
     ```scala
+    // uber jar
+    libraryDependencies += "io.valkey" % "valkey-glide" % "2.+"
+
     // osx-aarch_64
     libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "osx-aarch_64"
 

--- a/src/content/docs/migration/java/lettuce/installation.mdx
+++ b/src/content/docs/migration/java/lettuce/installation.mdx
@@ -26,8 +26,12 @@ Add the following dependency to your `pom.xml` file:
 
 ## Full Installations
 
-To use Valkey GLIDE, you must include a classifier to specify your platform architecture.\
 This section includes setup instructions for Gradle, Maven, and SBT, with or without OS detection tools.
+
+:::tip[Uber Jar vs Classifier]
+Starting from version 2.3.0, you can use the uber jar (no classifier needed), which bundles all platform binaries.
+The uber jar is larger in size. If you prefer a smaller dependency, use a platform-specific classifier for your OS.
+:::
 
 <Tabs>
   <TabItem label="Gradle">
@@ -42,6 +46,15 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with uber jar:
+
+    ```groovy
+    // with uber jar
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+'
     }
     ```
 
@@ -103,6 +116,13 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     <Code
       lang="xml"
       code={`
+<!--uber jar-->
+<dependency>
+<groupId>io.valkey</groupId>
+<artifactId>valkey-glide</artifactId>
+<version>${javaGlideLatest}</version>
+</dependency>
+
 <!--osx-aarch_64-->
 <dependency>
 <groupId>io.valkey</groupId>
@@ -153,6 +173,9 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     </Aside>
 
     ```scala
+    // uber jar
+    libraryDependencies += "io.valkey" % "valkey-glide" % "2.+"
+
     // osx-aarch_64
     libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "osx-aarch_64"
 

--- a/src/content/docs/migration/java/redisson/installation.mdx
+++ b/src/content/docs/migration/java/redisson/installation.mdx
@@ -25,8 +25,12 @@ Add the following dependency to your `pom.xml` file:
 
 ## Full Installations
 
-To use Valkey GLIDE, you must include a classifier to specify your platform architecture.\
 This section includes setup instructions for Gradle, Maven, and SBT, with or without OS detection tools.
+
+:::tip[Uber Jar vs Classifier]
+Starting from version 2.3.0, you can use the uber jar (no classifier needed), which bundles all platform binaries.
+The uber jar is larger in size. If you prefer a smaller dependency, use a platform-specific classifier for your OS.
+:::
 
 <Tabs>
   <TabItem label="Gradle">
@@ -41,6 +45,15 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     }
     dependencies {
         implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+', classifier: osdetector.classifier
+    }
+    ```
+
+    Example with uber jar:
+
+    ```groovy
+    // with uber jar
+    dependencies {
+        implementation group: 'io.valkey', name: 'valkey-glide', version: '2.+'
     }
     ```
 
@@ -102,6 +115,13 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     <Code
       lang="xml"
       code={`
+<!--uber jar-->
+<dependency>
+<groupId>io.valkey</groupId>
+<artifactId>valkey-glide</artifactId>
+<version>${javaGlideLatest}</version>
+</dependency>
+
 <!--osx-aarch_64-->
 <dependency>
 <groupId>io.valkey</groupId>
@@ -152,6 +172,9 @@ This section includes setup instructions for Gradle, Maven, and SBT, with or wit
     </Aside>
 
     ```scala
+    // uber jar
+    libraryDependencies += "io.valkey" % "valkey-glide" % "2.+"
+
     // osx-aarch_64
     libraryDependencies += "io.valkey" % "valkey-glide" % "2.+" classifier "osx-aarch_64"
 


### PR DESCRIPTION

### Summary

- Add uber jar as alternative to classifier-based dependencies starting from version 2.3.0
- Update quickstart guide to show simplified Gradle dependency without OS detector plugin
- Add uber jar examples across all installation documentation (Maven, Gradle, SBT)
- Include tip callouts explaining uber jar vs classifier trade-offs (size vs convenience)
- Add osx-aarch_64 to supported classifiers list
- Simplify installation instructions by removing mandatory classifier requirement language
- Update migration guides for Jedis, Lettuce, and Redisson with uber jar examples

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Content Changes

Uber jar documentation

### Implementation

<!--
Describe the implementation details. Highlight key content changes and call out any areas where you want reviewers to pay extra attention
-->

### Testing

<!--
Describe what tests have been conducted (e.g., build verification, link checking, visual review)
-->

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] All commits are signed off with `--signoff` flag.
- [ ] `pnpm build` runs successfully.
- [ ] Links have been checked for validity.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
