### PR TITLE
Add "Coming Soon" pre-release indicators for C# client documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -341,8 +341,9 @@ export default defineConfig({
                   link: "https://pkg.go.dev/github.com/valkey-io/valkey-glide/go/v2",
                   attrs: { style: "font-style: italic", target: "_blank" },
                 },
+                // TODO: Remove "(Coming Soon)" when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216)
                 {
-                  label: "C#",
+                  label: "C# (Coming Soon)",
                   link: "https://github.com/valkey-io/valkey-glide-csharp",
                   attrs: { style: "font-style: italic", target: "_blank" },
                 },

--- a/src/content/docs/commons/supported-languages-buttons.mdx
+++ b/src/content/docs/commons/supported-languages-buttons.mdx
@@ -2,7 +2,7 @@
 title: Supported Languages Buttons
 ---
 
-import { LinkButton } from '@astrojs/starlight/components';
+import { Badge, LinkButton } from '@astrojs/starlight/components';
 import ButtonGroup from '../../../components/ButtonGroup.astro';
 
 <ButtonGroup>
@@ -10,6 +10,9 @@ import ButtonGroup from '../../../components/ButtonGroup.astro';
   <LinkButton icon="seti:java" iconPlacement="start" href="/getting-started/quickstart?lang=java"> Java </LinkButton>
   <LinkButton icon="node" iconPlacement="start" href="/getting-started/quickstart?lang=node"> Node.js </LinkButton>
   <LinkButton icon="seti:go" iconPlacement="start" href="/getting-started/quickstart?lang=go"> Go </LinkButton>
-  <LinkButton icon="seti:c-sharp" iconPlacement="start" href="/getting-started/quickstart?lang=csharp"> C# </LinkButton>
+
+  {/* TODO: Remove "coming soon" badge when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
+
+  <LinkButton icon="seti:c-sharp" iconPlacement="start" href="/getting-started/quickstart?lang=csharp"> C# <Badge text="coming soon!" variant="caution" /> </LinkButton>
   <LinkButton icon="seti:php" iconPlacement="start" href="/getting-started/quickstart?lang=php"> PHP </LinkButton>
 </ButtonGroup>

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -168,7 +168,7 @@ Windows support is currently available only for Valkey-GLIDE Java
 
   <TabItem label="C#">
     :::caution[Coming Soon]
-    The C# client is not yet generally available. The API may change before the official release.
+    The C# client is not yet generally available.
     :::
 
     **Requirements:** .NET 8.0+

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -164,7 +164,13 @@ Windows support is currently available only for Valkey-GLIDE Java
     ```
   </TabItem>
 
+  {/* TODO: Remove "Coming Soon" caution when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
+
   <TabItem label="C#">
+    :::caution[Coming Soon]
+    The C# client is not yet generally available. The API may change before the official release.
+    :::
+
     **Requirements:** .NET 8.0+
 
     ```bash

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -295,7 +295,7 @@ Windows support is currently available only for Valkey-GLIDE Java
 
   <TabItem label="C#">
     :::caution[Coming Soon]
-    The C# client is not yet generally available. The API may change before the official release.
+    The C# client is not yet generally available.
     :::
 
     **Requirements:** .NET 8.0+

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -291,7 +291,13 @@ Windows support is currently available only for Valkey-GLIDE Java
     ```
   </TabItem>
 
+  {/* TODO: Remove "Coming Soon" caution when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
+
   <TabItem label="C#">
+    :::caution[Coming Soon]
+    The C# client is not yet generally available. The API may change before the official release.
+    :::
+
     **Requirements:** .NET 8.0+
 
     To get started, Valkey GLIDE C# is available on [NuGet](https://www.nuget.org/packages/Valkey.Glide).


### PR DESCRIPTION
### Summary

Add "Coming Soon" pre-release indicators for the C# client documentation. The C# client isn't ready for general availability yet, so this restores and adds warnings to set expectations — while keeping all the actual documentation content from #173 intact.

Each change includes a TODO comment linking to https://github.com/valkey-io/valkey-glide/issues/216 so they can be easily found and removed when the C# client is GA.

### Issue Link

Related: https://github.com/valkey-io/valkey-glide/issues/216

### Content Changes

- Restored the `Badge` import and "coming soon!" caution badge on the C# language button in `supported-languages-buttons.mdx` (reverts part of #173)
- Added "Coming Soon" caution asides to the C# install tabs in `quickstart.mdx` and `installation.mdx`
- Labeled the C# API reference sidebar entry as "C# (Coming Soon)" in `astro.config.mjs`
- Added TODO comments referencing valkey-io/valkey-glide#216 at each change site

### Implementation

Minimal changes across 4 files. The caution asides use the existing `:::caution[Coming Soon]` pattern already used elsewhere in the docs (e.g., `tracking-resources.mdx`, `tls.mdx`). The badge on the language button matches the original pattern that existed before #173.

### Testing

- `pnpm build` passes successfully (102 pages built)
- `pnpm format` runs clean with no formatting changes

### Checklist

Before submitting the PR make sure the following are checked:

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] ~~Links have been checked for validity.~~
- [x] Destination branch is correct - `main`
- [x] Create merge commit if merging release branch into main, squash otherwise.