### PR TITLE
Exclude broken links from GLIDE api reference

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,6 +173,10 @@ jobs:
           path: dist
           retention-days: 1
 
+      # Once glide 2.4 is release, we need to remove the excluded links.
+      - name: Check excluded links are still present
+        run: ./scripts/check-excluded-links.sh dist
+
       - name: Check external links
         uses: lycheeverse/lychee-action@v2.8.0
         with:

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,4 +18,12 @@ exclude = [
     '.*/languages/java/api.*',
     '.*/languages/nodejs/api.*',
     '.*/languages/python/api.*',
+
+    # Broken upstream links in generated API docs (cannot fix until upstream is updated)
+    'https://valkey\.io/commands/echo/%3Evalkey\.io%3C/a%3E%20for%20details\.%3C/dd%3E%3Cdt%3E%3Cspan%20class=',
+    'https://valkey\.io/commands/echo/%3Evalkey\.io%3C/a%3E%20for%20details\.%3C/dd%3E%3C/dl%3E%3C/li%3E%3C/ul%3E%3Ca%20id=',
+    'https://valkey\.io/docs/commands/randomkey/',
+    'https://valkey\.io/docs/latest/commands/sinter/',
+    'https://valkey\.io/docs/latest/commands/function-dump/',
+    'https://valkey\.io/docs/latest/commands/function-restore/',
 ]

--- a/scripts/check-excluded-links.sh
+++ b/scripts/check-excluded-links.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check if excluded broken upstream links still appear in the built dist/ output.
+# If any are no longer found, they've been fixed upstream and the exclusion in lychee.toml should be removed.
+
+set -euo pipefail
+
+DIST_DIR="${1:-dist}"
+
+LINKS=(
+  "https://valkey.io/docs/commands/randomkey/"
+  "https://valkey.io/docs/latest/commands/sinter/"
+  "https://valkey.io/docs/latest/commands/function-dump/"
+  "https://valkey.io/docs/latest/commands/function-restore/"
+)
+
+removed=()
+
+for link in "${LINKS[@]}"; do
+  if ! grep -rqF "$link" "$DIST_DIR"; then
+    removed+=("$link")
+    echo "NOT FOUND: $link"
+  else
+    echo "Still present: $link"
+  fi
+done
+
+if [ ${#removed[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: ${#removed[@]} link(s) no longer appear in $DIST_DIR."
+  echo "Please remove them from the exclude list in lychee.toml."
+  exit 1
+fi
+
+echo ""
+echo "All excluded links are still present. No changes needed."


### PR DESCRIPTION
### Summary

This PR add an exclude this for known broken links in the GLIDE client api reference docs. These links are upstream and and has been [fixed](https://github.com/valkey-io/valkey-glide/pull/5734). However since we build the api reference docs from the latest release they won't be fixed until 2.4. 

We also added a script to notify us when these links are gone, and thus to clean up the exclude list.
