### PR TITLE
Remove "Coming Soon" pre-release indicators for C# client

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -353,9 +353,8 @@ export default defineConfig({
                   link: "https://pkg.go.dev/github.com/valkey-io/valkey-glide/go/v2",
                   attrs: { style: "font-style: italic", target: "_blank" },
                 },
-                // TODO: Remove "(Coming Soon)" when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216)
                 {
-                  label: "C# (Coming Soon)",
+                  label: "C#",
                   link: "https://github.com/valkey-io/valkey-glide-csharp",
                   attrs: { style: "font-style: italic", target: "_blank" },
                 },

--- a/src/content/docs/commons/supported-languages-buttons.mdx
+++ b/src/content/docs/commons/supported-languages-buttons.mdx
@@ -2,7 +2,7 @@
 title: Supported Languages Buttons
 ---
 
-import { Badge, LinkButton } from '@astrojs/starlight/components';
+import { LinkButton } from '@astrojs/starlight/components';
 import ButtonGroup from '../../../components/ButtonGroup.astro';
 
 <ButtonGroup>
@@ -10,9 +10,6 @@ import ButtonGroup from '../../../components/ButtonGroup.astro';
   <LinkButton icon="seti:java" iconPlacement="start" href="/getting-started/quickstart?lang=java"> Java </LinkButton>
   <LinkButton icon="node" iconPlacement="start" href="/getting-started/quickstart?lang=node"> Node.js </LinkButton>
   <LinkButton icon="seti:go" iconPlacement="start" href="/getting-started/quickstart?lang=go"> Go </LinkButton>
-
-  {/* TODO: Remove "coming soon" badge when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
-
-  <LinkButton icon="seti:c-sharp" iconPlacement="start" href="/getting-started/quickstart?lang=csharp"> C# <Badge text="coming soon!" variant="caution" /> </LinkButton>
+  <LinkButton icon="seti:c-sharp" iconPlacement="start" href="/getting-started/quickstart?lang=csharp"> C# </LinkButton>
   <LinkButton icon="seti:php" iconPlacement="start" href="/getting-started/quickstart?lang=php"> PHP </LinkButton>
 </ButtonGroup>

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -166,13 +166,7 @@ Windows support is currently available only for Valkey-GLIDE Java
     ```
   </TabItem>
 
-  {/* TODO: Remove "Coming Soon" caution when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
-
   <TabItem label="C#">
-    :::caution[Coming Soon]
-    The C# client is not yet generally available.
-    :::
-
     **Requirements:** .NET 8.0+
 
     ```bash

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -315,13 +315,7 @@ Windows support is currently available only for Valkey-GLIDE Java
     ```
   </TabItem>
 
-  {/* TODO: Remove "Coming Soon" caution when C# is GA (https://github.com/valkey-io/valkey-glide/issues/216) */}
-
   <TabItem label="C#">
-    :::caution[Coming Soon]
-    The C# client is not yet generally available.
-    :::
-
     **Requirements:** .NET 8.0+
 
     To get started, Valkey GLIDE C# is available on [NuGet](https://www.nuget.org/packages/Valkey.Glide).


### PR DESCRIPTION
### Summary

Remove the "Coming Soon" pre-release indicators for the C# client documentation. The C# client has been released and is now generally available, so these warnings are no longer needed.

This reverts the changes from #183.

### Content Changes

- Removed the `Badge` import and "coming soon!" caution badge from the C# language button in `supported-languages-buttons.mdx`
- Removed "Coming Soon" caution asides from the C# install tabs in `quickstart.mdx` and `installation.mdx`
- Renamed the C# API reference sidebar entry from "C# (Coming Soon)" back to "C#" in `astro.config.mjs`
- Removed all TODO comments referencing valkey-io/valkey-glide#216

### Checklist

- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] Destination branch is correct - `main`