### PR TITLE
feat: Add automated compilation validation for C# code examples

### DIFF
--- a/.github/workflows/check-csharp-examples.yml
+++ b/.github/workflows/check-csharp-examples.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Checkout valkey-glide-docs
         uses: actions/checkout@v4
 
+      # Skip checking out the 'valkey-glide' submodule
+      # because it is not needed to validate the examples.
       - name: Checkout valkey-glide-csharp
         uses: actions/checkout@v4
         with:
@@ -31,9 +33,14 @@ jobs:
         with:
           python-version: "3.x"
 
+      # Skip building Rust core ('SkipCargo') because we only need
+      # the managed C# assembly as a reference for syntax validation.
       - name: Build Valkey.Glide DLL
         working-directory: valkey-glide-csharp
-        run: dotnet build sources/Valkey.Glide/ --configuration Release /p:SkipCargo=true
+        run: |
+          dotnet build sources/Valkey.Glide/ \
+            --configuration Release \
+            /p:SkipCargo=true
 
       - name: Run C# Example Validation
         run: |

--- a/.github/workflows/check-csharp-examples.yml
+++ b/.github/workflows/check-csharp-examples.yml
@@ -10,13 +10,16 @@ permissions:
 jobs:
   check-csharp-examples:
     runs-on: ubuntu-latest
-    env:
-      GLIDE_DLL: Valkey.Glide.dll
-      VALIDATOR_SCRIPT: validate_examples.py
 
     steps:
-      - name: Checkout Docs Repository
+      - name: Checkout valkey-glide-docs
         uses: actions/checkout@v4
+
+      - name: Checkout valkey-glide-csharp
+        uses: actions/checkout@v4
+        with:
+          repository: valkey-io/valkey-glide-csharp
+          path: valkey-glide-csharp
 
       - name: Setup .NET 8.0 SDK
         uses: actions/setup-dotnet@v4
@@ -28,18 +31,17 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Download Valkey.Glide DLL from NuGet
-        run: |
-          sudo apt-get install -y nuget
-          nuget install Valkey.Glide -OutputDirectory nuget_packages
-          cp nuget_packages/Valkey.Glide.*/lib/net8.0/Valkey.Glide.dll ${{ env.GLIDE_DLL }}
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
 
-      - name: Download validator script
-        run: |
-          curl -sL https://raw.githubusercontent.com/valkey-io/valkey-glide-csharp/main/scripts/validate_examples.py -o ${{ env.VALIDATOR_SCRIPT }}
+      - name: Build Valkey.Glide DLL
+        working-directory: valkey-glide-csharp
+        run: task build target=lib
 
       - name: Run C# Example Validation
         run: |
           python scripts/check_csharp_examples.py \
-            --validator ${{ env.VALIDATOR_SCRIPT }} \
-            --glide-dll ${{ env.GLIDE_DLL }}
+            --validator valkey-glide-csharp/scripts/validate_examples.py \
+            --glide-dll valkey-glide-csharp/sources/Valkey.Glide/bin/Release/net8.0/Valkey.Glide.dll

--- a/.github/workflows/check-csharp-examples.yml
+++ b/.github/workflows/check-csharp-examples.yml
@@ -31,14 +31,9 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-
       - name: Build Valkey.Glide DLL
         working-directory: valkey-glide-csharp
-        run: task build target=lib
+        run: dotnet build sources/Valkey.Glide/ --configuration Release /p:SkipCargo=true
 
       - name: Run C# Example Validation
         run: |

--- a/.github/workflows/check-csharp-examples.yml
+++ b/.github/workflows/check-csharp-examples.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       GLIDE_DLL: Valkey.Glide.dll
       VALIDATOR_SCRIPT: validate_examples.py
-    
+
     steps:
       - name: Checkout Docs Repository
         uses: actions/checkout@v4

--- a/.github/workflows/check-csharp-examples.yml
+++ b/.github/workflows/check-csharp-examples.yml
@@ -1,0 +1,45 @@
+name: Check C# Examples
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-csharp-examples:
+    runs-on: ubuntu-latest
+    env:
+      GLIDE_DLL: Valkey.Glide.dll
+      VALIDATOR_SCRIPT: validate_examples.py
+    
+    steps:
+      - name: Checkout Docs Repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8.0 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Download Valkey.Glide DLL from NuGet
+        run: |
+          sudo apt-get install -y nuget
+          nuget install Valkey.Glide -OutputDirectory nuget_packages
+          cp nuget_packages/Valkey.Glide.*/lib/net8.0/Valkey.Glide.dll ${{ env.GLIDE_DLL }}
+
+      - name: Download validator script
+        run: |
+          curl -sL https://raw.githubusercontent.com/valkey-io/valkey-glide-csharp/main/scripts/validate_examples.py -o ${{ env.VALIDATOR_SCRIPT }}
+
+      - name: Run C# Example Validation
+        run: |
+          python scripts/check_csharp_examples.py \
+            --validator ${{ env.VALIDATOR_SCRIPT }} \
+            --glide-dll ${{ env.GLIDE_DLL }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ doc-gen/valkey-glide/
 
 # Kiro files
 .kiro/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/scripts/check_csharp_examples.py
+++ b/scripts/check_csharp_examples.py
@@ -124,7 +124,7 @@ def main() -> None:
 
     try:
         with tmp_file as fh:
-            json.dump(examples, fh, indent=2)
+            json.dump(examples, fh, indent=2, sort_keys=True)
 
         result = subprocess.run(
             [

--- a/scripts/check_csharp_examples.py
+++ b/scripts/check_csharp_examples.py
@@ -112,11 +112,18 @@ def main() -> None:
     if not examples:
         sys.exit(0)
 
-    # Step 2: Write to temp file and validate
-    tmp_path = os.path.join(tempfile.gettempdir(), f"csharp_examples_{os.getpid()}.json")
+    # Step 2: Write to temp file and validate.
+    tmp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="csharp_examples_",
+        suffix=".json",
+        delete=False,
+    )
+    tmp_path = tmp_file.name
 
     try:
-        with open(tmp_path, "w", encoding="utf-8") as fh:
+        with tmp_file as fh:
             json.dump(examples, fh, indent=2)
 
         result = subprocess.run(
@@ -129,6 +136,7 @@ def main() -> None:
             check=False,
         )
         sys.exit(result.returncode)
+    
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)

--- a/scripts/check_csharp_examples.py
+++ b/scripts/check_csharp_examples.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Extract C# examples from MDX docs and validate them.
+
+1. Extracts C# code blocks from MDX files.
+2. Writes them to a temporary JSON file.
+3. Runs the validator script from 'valkey-glide-csharp'.
+4. Cleans up and propagates the exit code.
+
+Usage:
+    python scripts/check_csharp_examples.py
+        --validator <path_to_validate_examples.py>
+        --glide-dll <path_to_Valkey.Glide.dll>
+
+Options:
+    --validator      Path to the validate_examples.py script from the 'valkey-glide-csharp' repository.
+    --glide-dll      Path to the built Valkey.Glide.dll to reference during compilation.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# Repository root is one level up from this script's directory (scripts/).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DOCS_DIR = os.path.join(_REPO_ROOT, "src", "content", "docs")
+
+# Matches a ```csharp ... ``` fenced code block, capturing the content.
+# Allows leading whitespace before fences (common in MDX tab components).
+_CSHARP_BLOCK_RE = re.compile(
+    r"^\s*```csharp\s*\n(.*?)^\s*```\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def extract_from_file(filepath: str) -> dict[str, str]:
+    """Extract all C# fenced code blocks from a single MDX file.
+
+    Returns a dict mapping "<filepath>:<line_number>" to the code string.
+    """
+    with open(filepath, encoding="utf-8") as fh:
+        content = fh.read()
+
+    examples: dict[str, str] = {}
+    for match in _CSHARP_BLOCK_RE.finditer(content):
+        line_number = content[: match.start()].count("\n") + 1
+        examples[f"{filepath}:{line_number}"] = match.group(1)
+
+    return examples
+
+
+def extract_all(docs_dir: str) -> dict[str, str]:
+    """Recursively walk directory for .mdx files and extract C# blocks."""
+    examples: dict[str, str] = {}
+
+    for root, _dirs, files in os.walk(docs_dir):
+        for fname in sorted(files):
+            if fname.endswith(".mdx"):
+                examples.update(extract_from_file(os.path.join(root, fname)))
+
+    return examples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract C# examples from MDX docs and validate them."
+    )
+    parser.add_argument(
+        "--validator",
+        required=True,
+        help="Path to the validate_examples.py script.",
+    )
+    parser.add_argument(
+        "--glide-dll",
+        required=True,
+        help="Path to the built Valkey.Glide.dll.",
+    )
+    args = parser.parse_args()
+
+    validator_path = os.path.abspath(args.validator)
+    dll_path = os.path.abspath(args.glide_dll)
+
+    # Validate inputs
+    if not os.path.isfile(validator_path):
+        print(f"Error: validator script not found: {validator_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isfile(dll_path):
+        print(f"Error: DLL not found: {dll_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isdir(_DOCS_DIR):
+        print(f"Error: docs directory not found: {_DOCS_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    # Verify we can run the validator with Python
+    result = subprocess.run(
+        [sys.executable, validator_path, "--help"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: cannot run validator script: {validator_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Step 1: Extract examples from MDX files
+    examples = extract_all(_DOCS_DIR)
+    print(f"Extracted {len(examples)} C# code example(s).")
+
+    if not examples:
+        sys.exit(0)
+
+    # Step 2: Write to temp file and validate
+    tmp_path = os.path.join(tempfile.gettempdir(), f"csharp_examples_{os.getpid()}.json")
+
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(examples, fh, indent=2)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                validator_path,
+                "--examples", tmp_path,
+                "--glide-dll", dll_path,
+            ],
+            check=False,
+        )
+        sys.exit(result.returncode)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_csharp_examples.py
+++ b/scripts/check_csharp_examples.py
@@ -36,30 +36,27 @@ _CSHARP_BLOCK_RE = re.compile(
 )
 
 
-def extract_from_file(filepath: str) -> dict[str, str]:
-    """Extract all C# fenced code blocks from a single MDX file.
-
-    Returns a dict mapping "<filepath>:<line_number>" to the code string.
-    """
-    with open(filepath, encoding="utf-8") as fh:
-        content = fh.read()
-
-    examples: dict[str, str] = {}
-    for match in _CSHARP_BLOCK_RE.finditer(content):
-        line_number = content[: match.start()].count("\n") + 1
-        examples[f"{filepath}:{line_number}"] = match.group(1)
-
-    return examples
-
-
 def extract_all(docs_dir: str) -> dict[str, str]:
-    """Recursively walk directory for .mdx files and extract C# blocks."""
+    """Recursively walk docs_dir for .mdx files and extract C# blocks.
+
+    Returns a dict mapping "<repo_relative_path>:<line_number>" to the
+    code string.
+    """
     examples: dict[str, str] = {}
 
     for root, _dirs, files in os.walk(docs_dir):
         for fname in sorted(files):
-            if fname.endswith(".mdx"):
-                examples.update(extract_from_file(os.path.join(root, fname)))
+            if not fname.endswith(".mdx"):
+                continue
+            
+            filepath = os.path.join(root, fname)
+            with open(filepath, encoding="utf-8") as fh:
+                content = fh.read()
+
+            for match in _CSHARP_BLOCK_RE.finditer(content):
+                key_path = os.path.relpath(filepath, _REPO_ROOT)
+                line_number = content[: match.start()].count("\n") + 1
+                examples[f"{key_path}:{line_number}"] = match.group(1)
 
     return examples
 

--- a/src/content/docs/commands/valkey-string.mdx
+++ b/src/content/docs/commands/valkey-string.mdx
@@ -252,7 +252,7 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     using Valkey.Glide;
 
     // To GlideString[]
-    GlideString[] gsArr1 = new string[] { "a", "b" }.ToGlideStrings();                              // from string[]
+    GlideString[] gsArr1 = new string[] { "a", "b" }.ToGlideStrings();                       // from string[]
     GlideString[] gsArr2 = new[] { new byte[] {0x01}, new byte[] {0x02} }.ToGlideStrings();  // from byte[][]
 
     // From GlideString[]

--- a/src/content/docs/commands/valkey-string.mdx
+++ b/src/content/docs/commands/valkey-string.mdx
@@ -219,20 +219,18 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
 
     #### Type Conversion
 
-    `GlideString` supports implicit conversions from `string` and `byte[]`, so you can assign them directly:
+    Valkey GLIDE supports implicit conversions between `GlideString` and both `string` and `byte[]`:
 
     ```csharp
-    GlideString gs1 = "hello";                          // implicit string → GlideString
-    GlideString gs2 = new byte[] { 0x01, 0x02, 0x03 };  // implicit byte[] → GlideString
-    ```
+    using Valkey.Glide;
 
-    To convert back from `GlideString`:
+    // To GlideString
+    GlideString gs1 = "hello";                          // from string
+    GlideString gs2 = new byte[] { 0x01, 0x02, 0x03 };  // from byte[]
 
-    ```csharp
-    GlideString gs1 = "hello";
-    GlideString gs2 = new byte[] { 0x01, 0x02, 0x03 };
-    string text = gs1;   // implicit from GlideString → string
-    byte[] bytes = gs2;  // implicit from GlideString → byte[]
+    // From GlideString
+    string str = gs1;    // to string
+    byte[] bytes = gs2;  // to byte[]
     ```
 
     It also provides `.ToGlideString()` extension methods for common types:
@@ -251,9 +249,15 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     Batch conversions are also available:
 
     ```csharp
-    GlideString[] arr = new[] { "a", "b" }.ToGlideStrings();   // string[] → GlideString[]
-    string[] back = arr.ToStrings();                           // GlideString[] → string[]
-    byte[][] raw = arr.ToByteArrays();                         // GlideString[] → byte[][]
+    using Valkey.Glide;
+
+    // To GlideString[]
+    GlideString[] gsArr1 = new string[] { "a", "b" }.ToGlideStrings();                              // from string[]
+    GlideString[] gsArr2 = new[] { new byte[] {0x01}, new byte[] {0x02} }.ToGlideStrings();  // from byte[][]
+
+    // From GlideString[]
+    string[] strArr = gsArr1.ToStrings();       // to string[]
+    byte[][] bytesArr = gsArr2.ToByteArrays();  // to byte[][]
     ```
   </TabItem>
 

--- a/src/content/docs/commands/valkey-string.mdx
+++ b/src/content/docs/commands/valkey-string.mdx
@@ -203,10 +203,14 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
 
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Using regular strings
     await client.SetAsync("key", "value");
-    string? result = await client.GetAsync("key"); // Returns "value"
+    var value = await client.GetAsync("key"); // Returns "value"
 
     // Using GlideString for binary data
     var binaryKey = new byte[] { 0x01, 0x02, 0x03, 0xFE }.ToGlideString();
@@ -225,8 +229,10 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     To convert back from `GlideString`:
 
     ```csharp
-    string text = gs1;   // implicit to GlideString → string
-    byte[] bytes = gs2;  // implicit to GlideString → byte[]
+    GlideString gs1 = "hello";
+    GlideString gs2 = new byte[] { 0x01, 0x02, 0x03 };
+    string text = gs1;   // implicit from GlideString → string
+    byte[] bytes = gs2;  // implicit from GlideString → byte[]
     ```
 
     It also provides `.ToGlideString()` extension methods for common types:

--- a/src/content/docs/concepts/architecture/memory-model.mdx
+++ b/src/content/docs/concepts/architecture/memory-model.mdx
@@ -208,6 +208,7 @@ expected.
 
   <TabItem label="C#">
     ```csharp
+    using System.Diagnostics;
     long rss = Process.GetCurrentProcess().WorkingSet64;
     ```
   </TabItem>

--- a/src/content/docs/concepts/client-features/batch-commands.mdx
+++ b/src/content/docs/concepts/client-features/batch-commands.mdx
@@ -236,14 +236,14 @@ Determines how errors are surfaced when calling `exec(...)`. It is passed direct
   </TabItem>
 
   <TabItem label="C#">
-    ```csharp
+    ```text
     // Standalone Mode
-    Task<object?[]> Exec(Batch batch, bool raiseOnError);
-    Task<object?[]> Exec(Batch batch, bool raiseOnError, BatchOptions options);
+    Task<object?[]?> Exec(Batch batch, bool raiseOnError);
+    Task<object?[]?> Exec(Batch batch, bool raiseOnError, Options.BatchOptions options);
 
     // Cluster Mode
-    Task<object?[]> Exec(ClusterBatch batch, bool raiseOnError);
-    Task<object?[]> Exec(ClusterBatch batch, bool raiseOnError, ClusterBatchOptions options);
+    Task<object?[]?> Exec(ClusterBatch batch, bool raiseOnError);
+    Task<object?[]?> Exec(ClusterBatch batch, bool raiseOnError, Options.ClusterBatchOptions options);
     ```
   </TabItem>
 </Tabs>
@@ -379,26 +379,39 @@ Behavior:
   <TabItem label="C#">
     ```csharp
     // Cluster pipeline with raiseOnError = false
+    using Valkey.Glide;
     using Valkey.Glide.Pipeline;
+    using static Valkey.Glide.ConnectionConfiguration;
 
-    var batch = new ClusterBatch(false);
-    batch.Set(key, "hello");
-    batch.LPop(key);
-    batch.Del(key);
-    batch.Rename(key, key2);
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
 
-    var result = await client.Exec(batch, raiseOnError: false);
-    Console.WriteLine($"Result is: [{string.Join(", ", result)}]");
+    var batch = new ClusterBatch(false)
+      .SetAsync("key", "hello")
+      .ListLeftPop("key")
+      .Delete("key")
+      .Rename("key", "key2");
+
+    var result = await clusterClient.Exec(batch, raiseOnError: false);
+    Console.WriteLine($"Result is: [{string.Join(", ", result!)}]");
     // Output: Result is: [OK, RequestException: WRONGTYPE..., 1, RequestException: no such key]
     ```
 
     ```csharp
     // Transaction with raiseOnError = true
-    var batch = new Batch(true);
-    batch.Set(key, "hello");
-    batch.LPop(key);
-    batch.Del(key);
-    batch.Rename(key, key2);
+    using Valkey.Glide;
+    using Valkey.Glide.Pipeline;
+    using static Valkey.Glide.Errors;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var batch = new Batch(true)
+      .SetAsync("key", "hello")
+      .ListLeftPop("key")
+      .Delete("key")
+      .Rename("key", "key2");
 
     try
     {
@@ -464,7 +477,7 @@ Configuration for **standalone** batches.
     using Valkey.Glide.Pipeline;
     using static Valkey.Glide.Pipeline.Options;
 
-    var options = new BatchOptions(timeout: TimeSpan.FromSeconds(2)); // 2 seconds
+    var options = new BatchOptions(timeout: 2000); // 2 seconds
     ```
   </TabItem>
 </Tabs>
@@ -610,7 +623,7 @@ The ClusterBatchRetryStrategy configuration is only for non-atomic cluster batch
     using static Valkey.Glide.Pipeline.Options;
 
     var options = new ClusterBatchOptions(
-        timeout: TimeSpan.FromSeconds(1),
+        timeout: 1000,
         retryStrategy: new ClusterBatchRetryStrategy(
             retryServerError: true,
             retryConnectionError: false

--- a/src/content/docs/concepts/client-features/cluster-scan.mdx
+++ b/src/content/docs/concepts/client-features/cluster-scan.mdx
@@ -42,7 +42,16 @@ To start iterating, create a `ClusterScanCursor`:
 
   <TabItem label="C#">
     ```csharp
-    var cursor = ClusterScanCursor.InitialCursor();
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(config);
+
+    await foreach (var key in clusterClient.ScanAsync())
+    {
+        Console.WriteLine($"Key: {key}");
+    }
     ```
   </TabItem>
 

--- a/src/content/docs/concepts/client-features/valkey-scripting.mdx
+++ b/src/content/docs/concepts/client-features/valkey-scripting.mdx
@@ -360,9 +360,10 @@ GLIDE then automatically caches scripts with each `invoke_script()` call.
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+
     using var script = new Script("return 'Hello'");
-    var hashValue = script.Hash;
-    Console.WriteLine($"Script hash: {hashValue}"); // SHA1 hash of the script
+    Console.WriteLine($"Script hash: {script.Hash}"); // SHA1 hash of the script
     ```
   </TabItem>
 </Tabs>
@@ -404,6 +405,8 @@ Scripts with identical code produce identical hashes, enabling efficient caching
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+
     using var script1 = new Script("return 'Hello'");
     using var script2 = new Script("return 'Hello'");
     System.Diagnostics.Debug.Assert(script1.Hash == script2.Hash); // Same hash

--- a/src/content/docs/concepts/client-features/valkey-scripting.mdx
+++ b/src/content/docs/concepts/client-features/valkey-scripting.mdx
@@ -204,14 +204,19 @@ Valkey provides `KEYS` and `ARGV` to handle input parameters:
 
   <TabItem label="C#">
     ```csharp
-    var productKey = "product:shoe:stock";
-    var buyQuantity = "3";
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    using var script = new Script("return redis.call('SET', KEYS[1], ARGV[1])");
 
     var options = new ScriptOptions()
-        .WithKeys(productKey)    // Maps to KEYS[1] in Lua
-        .WithArgs(buyQuantity);  // Maps to ARGV[1] in Lua
+      .WithKeys("mykey")     // Maps to KEYS[1] in Lua
+      .WithArgs("myvalue"); // Maps to ARGV[1] in Lua
 
-    var result = await client.ScriptInvokeAsync(purchaseScript, options);
+    var result = await client.ScriptInvokeAsync(script, options);
     ```
   </TabItem>
 </Tabs>
@@ -287,16 +292,26 @@ values directly into the script would create unique scripts each time, preventin
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var productKey = "product:shoe:stock";
+    var buyQuantity = "3";
+
     // Bad: Creates a new hash for each quantity
     using var badScript = new Script($"return redis.call('DECRBY', {productKey}, {buyQuantity})");
 
     // Good: Reuses the same cached script
     using var goodScript = new Script("return redis.call('DECRBY', KEYS[1], ARGV[1])");
-    var result = await client.ScriptInvokeAsync(
-        goodScript,
-        new ScriptOptions()
-          .WithKeys(productKey)
-          .WithArgs(buyQuantity));
+
+    var options = new ScriptOptions()
+      .WithKeys(productKey)
+      .WithArgs(buyQuantity);
+
+    var result = await client.ScriptInvokeAsync(goodScript, options);
     ```
   </TabItem>
 </Tabs>
@@ -391,7 +406,7 @@ Scripts with identical code produce identical hashes, enabling efficient caching
     ```csharp
     using var script1 = new Script("return 'Hello'");
     using var script2 = new Script("return 'Hello'");
-    Debug.Assert(script1.Hash == script2.Hash); // Same hash
+    System.Diagnostics.Debug.Assert(script1.Hash == script2.Hash); // Same hash
     ```
   </TabItem>
 </Tabs>
@@ -520,6 +535,12 @@ When executing a script in cluster mode, all `KEYS` must belong to the same shar
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
     // This works the same in cluster mode
     using var script = new Script("return redis.call('SET', KEYS[1], ARGV[1])");
     var result = await clusterClient.ScriptInvokeAsync(
@@ -593,16 +614,21 @@ GLIDE provide options for explicit control over script routing in cluster mode.
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    using var script = new Script("return 'Hello'");
 
     // Route to the node holding a specific key's slot
-    var route = new Route.SlotKeyRoute("user:1000", Route.SlotType.Primary);
+    var slotRoute = new Route.SlotKeyRoute("user:1000", Route.SlotType.Primary);
+    var slotRouteOptions = new ClusterScriptOptions().WithRoute(slotRoute);
+    var slotResult = await clusterClient.ScriptInvokeAsync(script, slotRouteOptions);
 
     // Route to all primary nodes
-    route = Route.AllPrimaries;
-
-    var result = await clusterClient.ScriptInvokeAsync(
-        script,
-        new ClusterScriptOptions().WithRoute(route));
+    var allRouteOptions = new ClusterScriptOptions().WithRoute(Route.AllPrimaries);
+    var allResult = await clusterClient.ScriptInvokeAsync(script, allRouteOptions);
     ```
   </TabItem>
 </Tabs>
@@ -735,7 +761,12 @@ To use Lua scripts within an atomic batch (MULTI/EXEC transaction), you must use
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
     using Valkey.Glide.Pipeline;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Script with keys and arguments
     var batch = new Batch(isAtomic: true);
@@ -746,10 +777,10 @@ To use Lua scripts within an atomic batch (MULTI/EXEC transaction), you must use
         "script-key",  // Key
         "script-value" // Argument
     });
-    batch.Get("script-key");
+    batch.GetAsync("script-key");
 
-    var results = await client.Exec(batch);
-    Console.WriteLine($"EVAL result: {results[0]}"); // OK
+    var results = await client.Exec(batch, raiseOnError: true);
+    Console.WriteLine($"EVAL result: {results![0]}"); // OK
     Console.WriteLine($"GET result: {results[1]}");  // script-value
     ```
   </TabItem>

--- a/src/content/docs/getting-started/basic-operations.mdx
+++ b/src/content/docs/getting-started/basic-operations.mdx
@@ -174,18 +174,15 @@ To update keys in Valkey, clients can send [SET](https://valkey.io/commands/set/
     using Valkey.Glide;
     using static Valkey.Glide.ConnectionConfiguration;
 
-    var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
-        .Build();
-
+    var config = new StandaloneClientConfigurationBuilder().Build();
     await using var client = await GlideClient.CreateClient(config);
 
     // Set a key-value pair
-    await client.StringSetAsync("user:1000", "john_doe");
+    await client.SetAsync("user:1000", "john_doe");
     Console.WriteLine("✓ Key set successfully");
 
     // Get the value
-    ValkeyValue value = await client.StringGetAsync("user:1000");
+    ValkeyValue value = await client.GetAsync("user:1000");
     Console.WriteLine($"✓ Retrieved value: {value}");
     ```
   </TabItem>
@@ -284,8 +281,14 @@ Clients can send [MSET](https://valkey.io/commands/mset/) and [MGET](https://val
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
     // Set multiple keys at once
-    await client.StringSetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
+    await client.SetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
     {
         new("user:1001", "alice"),
         new("user:1002", "bob"),
@@ -294,8 +297,7 @@ Clients can send [MSET](https://valkey.io/commands/mset/) and [MGET](https://val
     Console.WriteLine("✓ Multiple keys set");
 
     // Get multiple keys at once
-    ValkeyValue[] values = await client.StringGetAsync(
-        new ValkeyKey[] { "user:1001", "user:1002", "user:1003" });
+    var values = await client.GetAsync(["user:1001", "user:1002", "user:1003"]);
     Console.WriteLine($"✓ Retrieved values: {string.Join(", ", values)}");
     ```
   </TabItem>
@@ -348,9 +350,14 @@ Clients can also send [DEL](https://valkey.io/commands/del/) commands to delete 
 
   <TabItem label="C#">
     ```csharp
-    long deletedCount = await client.KeyDeleteAsync(
-        new ValkeyKey[] { "user:1001", "user:1002", "user:1003" });
-    Console.WriteLine($"✓ Deleted {deletedCount} keys");
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var count = await client.DeleteAsync(["user:1001", "user:1002", "user:1003"]);
+    Console.WriteLine($"✓ Deleted {count} keys");
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/connections/read-strategy.mdx
+++ b/src/content/docs/how-to/connections/read-strategy.mdx
@@ -118,10 +118,10 @@ Valkey GLIDE provides support for the following read strategies, allowing you to
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    await client.StringSetAsync("key1", "val1");
+    await client.SetAsync("key1", "val1");
 
-    // StringGetAsync will read from one of the replicas
-    await client.StringGetAsync("key1");
+    // GetAsync will read from one of the replicas
+    await client.GetAsync("key1");
     ```
   </TabItem>
 
@@ -248,10 +248,10 @@ When using the AZ Affinity read strategy, the `clientAz` setting is required to 
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    await client.StringSetAsync("key1", "val1");
+    await client.SetAsync("key1", "val1");
 
-    // StringGetAsync will read from one of the replicas in the same client's availability zone if they exist
-    await client.StringGetAsync("key1");
+    // GetAsync will read from one of the replicas in the same client's availability zone if they exist
+    await client.GetAsync("key1");
     ```
   </TabItem>
 
@@ -379,10 +379,10 @@ When using the AZ Affinity Replicas and Primary read strategy, the `clientAz` se
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    await client.StringSetAsync("key1", "val1");
+    await client.SetAsync("key1", "val1");
 
-    // StringGetAsync will read from one of the replicas or the primary in the same client's availability zone if they exist
-    await client.StringGetAsync("key1");
+    // GetAsync will read from one of the replicas or the primary in the same client's availability zone if they exist
+    await client.GetAsync("key1");
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/execute-custom-scripts.mdx
+++ b/src/content/docs/how-to/execute-custom-scripts.mdx
@@ -281,30 +281,9 @@ The following steps shows how to run a simple a custom Lua script using GLIDE.
 
   <TabItem label="C#">
     <Steps>
-      1. Define the lua script
-
-         ```csharp
-         var lua = @"
-         server.call('SET', KEYS[1], ARGV[1])
-         return KEYS[1] .. ': ' .. server.call('GET', KEYS[1])
-         ";
-         ```
-
-      2. Create a `Script` object with the Lua code
-
-         ```csharp
-         using var script = new Script(lua);
-         ```
-
-      3. Execute script with keys and arguments
-
-         ```csharp
-         var options = new ScriptOptions()
-             .WithKeys("username")
-             .WithArgs("John Doe");
-         var result = await client.ScriptInvokeAsync(script, options);
-         Console.WriteLine(result); // username: John Doe
-         ```
+      1. Define the Lua script as a string.
+      2. Create a `Script` object with the Lua code.
+      3. Execute the script using `ScriptInvokeAsync`.
     </Steps>
 
     <details>
@@ -314,23 +293,25 @@ The following steps shows how to run a simple a custom Lua script using GLIDE.
       using Valkey.Glide;
       using static Valkey.Glide.ConnectionConfiguration;
 
-      var config = new StandaloneClientConfigurationBuilder()
-          .WithAddress("localhost", 6379)
-          .Build();
+      var config = new StandaloneClientConfigurationBuilder().Build();
       await using var client = await GlideClient.CreateClient(config);
 
+      // 1. Define the Lua script as a string
       var lua = @"
       server.call('SET', KEYS[1], ARGV[1])
       return KEYS[1] .. ': ' .. server.call('GET', KEYS[1])
       ";
 
+      // 2. Create a `Script` object with the Lua code.
       using var script = new Script(lua);
 
+      // 3. Execute the script using `ScriptInvokeAsync`.
       var options = new ScriptOptions()
           .WithKeys("username")
           .WithArgs("John Doe");
       var result = await client.ScriptInvokeAsync(script, options);
-      Console.WriteLine(result);
+
+      Console.WriteLine(result); // username: John Doe
       ```
     </details>
   </TabItem>

--- a/src/content/docs/how-to/load-and-execute-functions.mdx
+++ b/src/content/docs/how-to/load-and-execute-functions.mdx
@@ -315,31 +315,9 @@ The following example shows a simple example of loading and executing a Valkey F
 
   <TabItem label="C#">
     <Steps>
-      1. Define the lua script.
-
-         ```csharp
-         var luaCode = @"#!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
-         end)
-         ";
-         ```
-
-      2. Load the function to Valkey.
-
-         ```csharp
-         await client.FunctionLoadAsync(luaCode, replace: true);
-         ```
-
-      3. Call the function.
-
-         ```csharp
-         await client.StringSetAsync("page:home:visits", "0");
-         var result = await client.FCallAsync("set_then_get",
-             ["page:home:visits"], ["1"]);
-         Console.WriteLine(result); // 1
-         ```
+      1. Define the Lua script as a string.
+      2. Load the function to Valkey using `FunctionLoadAsync`.
+      3. Call the function using `FCallAsync`.
     </Steps>
 
     <details>
@@ -354,6 +332,9 @@ The following example shows a simple example of loading and executing a Valkey F
           .Build();
       await using var client = await GlideClient.CreateClient(config);
 
+      await client.SetAsync("page:home:visits", "0");
+
+      // 1. Define the Lua script as a string.
       // lua code that updates a key and returns its new value
       var luaCode = @"#!lua name=page_visits
       server.register_function('update_visits', function(visits)
@@ -362,13 +343,11 @@ The following example shows a simple example of loading and executing a Valkey F
       end)
       ";
 
-      // loading the function to valkey
+      // 2. Load the function to Valkey using `FunctionLoadAsync`.
       await client.FunctionLoadAsync(luaCode, replace: true);
 
-      await client.StringSetAsync("page:home:visits", "0");
-      // calling the previously loaded function
-      var result = await client.FCallAsync("update_visits",
-          ["page:home:visits"], []);
+      // 3. Call the function using `FCallAsync`.
+      var result = await client.FCallAsync("update_visits", ["page:home:visits"], []);
       Console.WriteLine(result); // 1
       ```
     </details>
@@ -522,20 +501,27 @@ GLIDE clients implement `FCALL_RO` command to execute read-only functions.
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
     var result = await client.FCallReadOnlyAsync("get_value", ["mykey"], []);
     ```
 
     **With Routing (Cluster Mode)**
 
     ```csharp
-    // Route to all nodes
-    var allNodesResult = await client.FCallReadOnlyAsync("get_value", Route.AllNodes);
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
 
-    // Route to all primary nodes
-    var allPrimariesResult = await client.FCallReadOnlyAsync("get_value", Route.AllPrimaries);
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
 
-    // Route to a random node
-    var randomResult = await client.FCallReadOnlyAsync("get_value", Route.Random);
+    var allNodesResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.AllNodes);
+    var allPrimariesResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.AllPrimaries);
+    var randomResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.Random);
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/publish-and-subscribe-messages.mdx
+++ b/src/content/docs/how-to/publish-and-subscribe-messages.mdx
@@ -314,18 +314,18 @@ No special configuration is needed at client creation time — you can subscribe
 
     // --- Exact channel subscriptions ---
 
-    await client.SubscribeAsync(new[] { "news", "updates" }, blockFor );  // Blocking
-    await client.SubscribeLazyAsync(new[] { "alerts" });                 // Non-blocking (lazy)
+    await client.SubscribeAsync(["news", "updates"], blockFor );  // Blocking
+    await client.SubscribeLazyAsync("alerts");                    // Non-blocking (lazy)
 
     // --- Pattern subscriptions ---
 
-    await client.PSubscribeAsync(new[] { "chat*", "event*" }, blockFor);  // Blocking
-    await client.PSubscribeLazyAsync(new[] { "log*" });                   // Non-blocking (lazy)
+    await client.PSubscribeAsync(["chat*", "event*"], blockFor);  // Blocking
+    await client.PSubscribeLazyAsync("log*");                     // Non-blocking (lazy)
 
     // --- Sharded subscriptions (cluster mode only) ---
 
-    await client.SSubscribeAsync(new[] { "shard-ch1" }, blockFor);  // Blocking
-    await client.SSubscribeLazyAsync(new[] { "shard-ch2" });        // Non-blocking (lazy)
+    await client.SSubscribeAsync("shard-ch1", blockFor);  // Blocking
+    await client.SSubscribeLazyAsync("shard-ch2");        // Non-blocking (lazy)
 
     // Retrieve messages via polling
     var queue = client.PubSubQueue!;
@@ -653,22 +653,26 @@ To use callback-based delivery, provide a subscription configuration with a call
     var subscriptionConfig = new StandalonePubSubSubscriptionConfig()
         .WithCallback(PubSubCallback);
 
-    var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
+    var subscriberConfig = new StandaloneClientConfigurationBuilder()
         .WithPubSubSubscriptions(subscriptionConfig)
         .Build();
-
-    await using var client = await GlideClient.CreateClient(config);
+    await using var subscriber = await GlideClient.CreateClient(subscriberConfig);
 
     // Subscribe dynamically — messages are delivered to the callback
-    await client.SubscribeAsync(new[] { "news" }, TimeSpan.FromSeconds(5));
+    await subscriber.SubscribeAsync("news", TimeSpan.FromSeconds(5));
 
     // Publish a message (from another client)
+    var publisherConfig = new StandaloneClientConfigurationBuilder().Build();
+    await using var publishingClient = await GlideClient.CreateClient(publisherConfig);
+
     await publishingClient.PublishAsync("news", "Hello!");
     await Task.Delay(500);
 
     // Verify the callback received the message
-    lock (received) { Debug.Assert(received.Contains("Hello!")); }
+    lock (received)
+    { 
+      System.Diagnostics.Debug.Assert(received.Contains("Hello!"));
+    }
     ```
   </TabItem>
 </Tabs>
@@ -1000,30 +1004,39 @@ Prior to GLIDE 2.3, runtime unsubscribing is not available. Subscriptions are re
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
     var blockFor = TimeSpan.FromSeconds(5);
 
     // Unsubscribe from specific exact channels (blocking)
-    await client.UnsubscribeAsync(new[] { "news" }, blockFor);
+    await client.UnsubscribeAsync("news", blockFor);
 
     // Unsubscribe from specific exact channels (lazy)
-    await client.UnsubscribeLazyAsync(new[] { "alerts" });
+    await client.UnsubscribeLazyAsync("alerts");
 
     // Unsubscribe from all exact channels (blocking)
-    await client.UnsubscribeAsync(PubSub.AllChannels, blockFor);
+    await client.UnsubscribeAsync(blockFor);
 
     // Unsubscribe from specific patterns (blocking)
-    await client.PUnsubscribeAsync(new[] { "chat*" }, blockFor);
+    await client.PUnsubscribeAsync("chat*", blockFor);
 
     // Unsubscribe from specific patterns (lazy)
-    await client.PUnsubscribeLazyAsync(new[] { "log*" });
+    await client.PUnsubscribeLazyAsync("log*");
 
     // Unsubscribe from all patterns (blocking)
-    await client.PUnsubscribeAsync(PubSub.AllPatterns, blockFor);
+    await client.PUnsubscribeAsync(blockFor);
 
     // Sharded unsubscribe (cluster mode only)
-    await clusterClient.SUnsubscribeAsync(new[] { "shard-ch1" }, blockFor);
-    await clusterClient.SUnsubscribeLazyAsync(new[] { "shard-ch2" });
-    await clusterClient.SUnsubscribeAsync(PubSub.AllShardedChannels, blockFor);
+    await clusterClient.SUnsubscribeAsync("shard-ch1", blockFor);
+    await clusterClient.SUnsubscribeLazyAsync("shard-ch2");
+    await clusterClient.SUnsubscribeAsync(blockFor);
     ```
   </TabItem>
 </Tabs>
@@ -1067,6 +1080,12 @@ Use `get_subscriptions()` to inspect the current subscription state. It returns 
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
     var state = await client.GetSubscriptionsAsync();
     Console.WriteLine($"Desired: {state.Desired}");
     Console.WriteLine($"Actual: {state.Actual}");

--- a/src/content/docs/how-to/scan-cluster.mdx
+++ b/src/content/docs/how-to/scan-cluster.mdx
@@ -80,13 +80,15 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
 
   <TabItem label="C#">
     ```csharp
-    var cursor = ClusterScanCursor.InitialCursor();
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
 
-    var allKeys = new List<ValkeyKey>();
-    while (!cursor.IsFinished)
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    await foreach (var key in clusterClient.ScanAsync())
     {
-        (cursor, var keys) = await client.ScanAsync(cursor);
-        allKeys.AddRange(keys);
+        Console.WriteLine($"Key: {key}");
     }
     ```
   </TabItem>
@@ -198,7 +200,14 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
 
   <TabItem label="C#">
     ```csharp
-    await client.StringSetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
+    using Valkey.Glide;
+    using Valkey.Glide.Commands.Options;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    await clusterClient.SetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
     {
         new("my_key1", "value1"),
         new("my_key2", "value2"),
@@ -206,14 +215,10 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
         new("something_else", "value4")
     });
 
-    var cursor = ClusterScanCursor.InitialCursor();
-    var scanOptions = new ScanOptions { MatchPattern = "*key*" };
-
-    var matchedKeys = new List<ValkeyKey>();
-    while (!cursor.IsFinished)
+    var options = new ScanOptions { MatchPattern = "*key*" };
+    await foreach (var key in clusterClient.ScanAsync(options))
     {
-        (cursor, var keys) = await client.ScanAsync(cursor, scanOptions);
-        matchedKeys.AddRange(keys);
+        Console.WriteLine($"Matching key: {key}");
     }
 
     // Returns matching keys such as ["my_key1", "my_key2", "not_my_key"]
@@ -321,7 +326,14 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
 
   <TabItem label="C#">
     ```csharp
-    await client.StringSetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
+    using Valkey.Glide;
+    using Valkey.Glide.Commands.Options;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    await clusterClient.SetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
     {
         new("my_key1", "value1"),
         new("my_key2", "value2"),
@@ -329,14 +341,10 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
         new("something_else", "value4")
     });
 
-    var cursor = ClusterScanCursor.InitialCursor();
-    var scanOptions = new ScanOptions { Count = 10 };
-
-    var allKeys = new List<ValkeyKey>();
-    while (!cursor.IsFinished)
+    var options = new ScanOptions { Count = 10 };
+    await foreach (var key in clusterClient.ScanAsync(options))
     {
-        (cursor, var keys) = await client.ScanAsync(cursor, scanOptions);
-        allKeys.AddRange(keys);
+        Console.WriteLine($"Key: {key}");
     }
 
     // Returns around `count` keys per iteration
@@ -442,25 +450,28 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
 
   <TabItem label="C#">
     ```csharp
-    await client.StringSetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
+    using Valkey.Glide;
+    using Valkey.Glide.Commands.Options;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    await clusterClient.SetAsync(new KeyValuePair<ValkeyKey, ValkeyValue>[]
     {
         new("key1", "value1"),
         new("key2", "value2"),
         new("key3", "value3")
     });
-    await client.SetAddAsync("this_is_a_set", new ValkeyValue[] { "value4" });
+    await clusterClient.SetAddAsync("this_is_a_set", new ValkeyValue[] { "value4" });
 
-    var cursor = ClusterScanCursor.InitialCursor();
-    var scanOptions = new ScanOptions { Type = ValkeyType.String };
-
-    var stringKeys = new List<ValkeyKey>();
-    while (!cursor.IsFinished)
+    var options = new ScanOptions { Type = ValkeyType.String };
+    await foreach (var key in clusterClient.ScanAsync(options))
     {
-        (cursor, var keys) = await client.ScanAsync(cursor, scanOptions);
-        stringKeys.AddRange(keys);
+        Console.WriteLine($"String key: {key}");
     }
 
-    // Output: ["key1", "key2", "key3"]
+    // keys: ["key1", "key2", "key3"]
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/security/dynamic-authentication.mdx
+++ b/src/content/docs/how-to/security/dynamic-authentication.mdx
@@ -162,10 +162,10 @@ Below are examples demonstrating how to utilize the dynamic password update feat
     await using var client = await GlideClusterClient.CreateClient(config);
 
     // Update password with lazy re-authentication.
-    await client.UpdateConnectionPassword("your-new-password");
+    await client.UpdateConnectionPasswordAsync("your-new-password");
 
     // Update password with immediate re-authentication.
-    await client.UpdateConnectionPassword("your-new-password", immediateAuth: true);
+    await client.UpdateConnectionPasswordAsync("your-new-password", immediateAuth: true);
 
     // Clear password with lazy re-authentication.
     await client.ClearConnectionPasswordAsync();
@@ -258,6 +258,8 @@ In scenarios where a username is not required (e.g., IAM authentication), you ca
 
   <TabItem label="C#">
     ```csharp
+    using static Valkey.Glide.ConnectionConfiguration;
+
     var config = new ClusterClientConfigurationBuilder()
         .WithAddress("address.example.com", 6379)
         .WithAuthentication("your-password-or-token")

--- a/src/content/docs/how-to/security/iam-integration.mdx
+++ b/src/content/docs/how-to/security/iam-integration.mdx
@@ -26,10 +26,10 @@ For GLIDE versions below 2.2, see the [guide](/how-to/security/iam-integration-u
 2. **Required Information**:
 
 * **username**: Your ElastiCache/MemoryDB username
-* **cluster_name**: Your cluster's name
+* **cluster\_name**: Your cluster's name
 * **service**: Either **ElastiCache** or **MemoryDB**
 * **region**: The AWS region where your cluster runs
-* **refresh_interval_seconds (Optional)**: How often to refresh the token. Default is **300 seconds (5 minutes)**
+* **refresh\_interval\_seconds (Optional)**: How often to refresh the token. Default is **300 seconds (5 minutes)**
 
 ## Examples
 

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -462,7 +462,7 @@ You can provide custom root certificates for TLS connections. This is useful whe
     using Valkey.Glide;
     using static Valkey.Glide.ConnectionConfiguration;
 
-    byte[] certData = Encoding.UTF8.GetBytes(
+    var certData = Encoding.UTF8.GetBytes(
         "-----BEGIN CERTIFICATE-----\n"
         + "MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKmzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\n"
         + "...\n"
@@ -470,7 +470,6 @@ You can provide custom root certificates for TLS connections. This is useful whe
     );
 
     var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("primary.example.com", 6379)
         .WithTls()
         .WithTrustedCertificate(certData)
         .Build();

--- a/src/content/docs/how-to/send-batch-commands.mdx
+++ b/src/content/docs/how-to/send-batch-commands.mdx
@@ -203,24 +203,22 @@ A transaction is an all-or-nothing set of commands sent in a single request to V
     using Valkey.Glide;
     using Valkey.Glide.Pipeline;
     using static Valkey.Glide.ConnectionConfiguration;
+    using static Valkey.Glide.Pipeline.Options;
 
-    // Create client configuration
-    var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
-        .Build();
-
+    // Create client
+    var config = new StandaloneClientConfigurationBuilder().Build();
     await using var client = await GlideClient.CreateClient(config);
 
     // Configure batch options
     var options = new BatchOptions(timeout: 2000);
 
     // Create atomic batch (true indicates atomic/transaction mode)
-    var atomicBatch = new Batch(isAtomic: true);
-    atomicBatch.StringSetAsync("account:source", "100");
-    atomicBatch.StringSetAsync("account:dest", "0");
-    atomicBatch.StringIncrementAsync("account:dest", 50);
-    atomicBatch.StringDecrementAsync("account:source", 50);
-    atomicBatch.StringGetAsync("account:source");
+    var atomicBatch = new Batch(isAtomic: true)
+        .SetAsync("account:source", "100")
+        .SetAsync("account:dest", "0")
+        .IncrementAsync("account:dest", 50)
+        .DecrementAsync("account:source", 50)
+        .GetAsync("account:source");
 
     // Execute with raiseOnError = true
     var results = await client.Exec(atomicBatch, raiseOnError: true, options);
@@ -412,6 +410,7 @@ A transaction is an all-or-nothing set of commands sent in a single request to V
     using Valkey.Glide;
     using Valkey.Glide.Pipeline;
     using static Valkey.Glide.ConnectionConfiguration;
+    using static Valkey.Glide.Pipeline.Options;
 
     // Create client configuration
     var config = new ClusterClientConfigurationBuilder()
@@ -424,10 +423,10 @@ A transaction is an all-or-nothing set of commands sent in a single request to V
     var options = new ClusterBatchOptions(timeout: 3000);
 
     // Create atomic cluster batch (all keys map to same slot)
-    var atomicBatch = new ClusterBatch(isAtomic: true);
-    atomicBatch.StringSetAsync("user:100:visits", "1");
-    atomicBatch.StringIncrementAsync("user:100:visits", 5);
-    atomicBatch.StringGetAsync("user:100:visits");
+    var atomicBatch = new ClusterBatch(isAtomic: true)
+        .SetAsync("user:100:visits", "1")
+        .IncrementAsync("user:100:visits", 5)
+        .GetAsync("user:100:visits");
 
     var results = await client.Exec(atomicBatch, raiseOnError: true, options);
     Console.WriteLine($"Atomic Cluster Batch: {string.Join(", ", results!)}");
@@ -604,6 +603,7 @@ Pipelining is a group of commands sent in a single request that does not guarant
     using Valkey.Glide;
     using Valkey.Glide.Pipeline;
     using static Valkey.Glide.ConnectionConfiguration;
+    using static Valkey.Glide.Pipeline.Options;
 
     // Create client configuration
     var config = new StandaloneClientConfigurationBuilder()
@@ -616,11 +616,11 @@ Pipelining is a group of commands sent in a single request that does not guarant
     var options = new BatchOptions(timeout: 2000);
 
     // Create non-atomic batch (false indicates pipeline mode)
-    var pipeline = new Batch(isAtomic: false);
-    pipeline.StringSetAsync("temp:key1", "value1");
-    pipeline.StringSetAsync("temp:key2", "value2");
-    pipeline.StringGetAsync("temp:key1");
-    pipeline.StringGetAsync("temp:key2");
+    var pipeline = new Batch(isAtomic: false)
+        .SetAsync("temp:key1", "value1")
+        .SetAsync("temp:key2", "value2")
+        .GetAsync("temp:key1")
+        .GetAsync("temp:key2");
 
     var results = await client.Exec(pipeline, raiseOnError: false, options);
     Console.WriteLine($"Pipeline Results: {string.Join(", ", results!)}");
@@ -836,6 +836,7 @@ Pipelining is a group of commands sent in a single request that does not guarant
     using Valkey.Glide;
     using Valkey.Glide.Pipeline;
     using static Valkey.Glide.ConnectionConfiguration;
+    using static Valkey.Glide.Pipeline.Options;
 
     // Create client configuration
     var config = new ClusterClientConfigurationBuilder()
@@ -852,13 +853,13 @@ Pipelining is a group of commands sent in a single request that does not guarant
             retryConnectionError: true));
 
     // Create pipeline spanning multiple slots
-    var pipeline = new ClusterBatch(isAtomic: false);
-    pipeline.StringSetAsync("page:home:views", "100");
-    pipeline.StringIncrementAsync("page:home:views", 25);
-    pipeline.StringGetAsync("page:home:views");
-    pipeline.ListLeftPush("recent:logins", "user1");
-    pipeline.ListLeftPush("recent:logins", "user2");
-    pipeline.ListRange("recent:logins", 0, 1);
+    var pipeline = new ClusterBatch(isAtomic: false)
+        .SetAsync("page:home:views", "100")
+        .IncrementAsync("page:home:views", 25)
+        .GetAsync("page:home:views")
+        .ListLeftPush("recent:logins", "user1")
+        .ListLeftPush("recent:logins", "user2")
+        .ListRange("recent:logins", 0, 1);
 
     var results = await client.Exec(pipeline, raiseOnError: false, options);
     Console.WriteLine($"Pipeline Cluster Results: {string.Join(", ", results!)}");

--- a/src/content/docs/reference/scripting-reference.mdx
+++ b/src/content/docs/reference/scripting-reference.mdx
@@ -81,8 +81,14 @@ The following shows how to covert your `EVAL` command to GLIDE's `Script` interf
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
     // Old approach with custom commands (not recommended)
-    var result = await client.CustomCommandAsync(new GlideString[] {
+    var result = await client.CustomCommand(new GlideString[] {
         "EVAL",
         "return redis.call('SET', KEYS[1], ARGV[1])",
         "1",
@@ -174,13 +180,14 @@ The following shows how to covert your `EVAL` command to GLIDE's `Script` interf
     ```csharp
     // New approach with Script class (recommended)
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     using var script = new Script("return redis.call('SET', KEYS[1], ARGV[1])");
-    var result = await client.ScriptInvokeAsync(
-        script,
-        new ScriptOptions()
-            .WithKeys("mykey")
-            .WithArgs("myvalue"));
+    var options = new ScriptOptions().WithKeys("mykey").WithArgs("myvalue");
+    var result = await client.ScriptInvokeAsync(script, options);
     ```
   </TabItem>
 
@@ -307,6 +314,10 @@ end
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Read script from file
     var rateLimit = File.ReadAllText("rate_limit.lua");
@@ -507,6 +518,10 @@ end
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Read scripts from files
     var acquireLock = File.ReadAllText("acquire_lock.lua");
@@ -669,6 +684,10 @@ end
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Read script from file
     var conditionalUpdate = File.ReadAllText("conditional_update.lua");
@@ -807,7 +826,11 @@ end
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
-    using Valkey.Glide.Errors;
+    using static Valkey.Glide.Errors;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Handle script execution errors
     using var script = new Script("return redis.call('INCR', 'not_a_number')");
@@ -1025,12 +1048,11 @@ When a client timeout occurs, the client stops waiting for a response, but the s
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
-    using Valkey.Glide.Errors;
+    using static Valkey.Glide.Errors;
     using static Valkey.Glide.ConnectionConfiguration;
 
     // Configure client timeout for long-running scripts
     var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
         .WithRequestTimeout(TimeSpan.FromSeconds(30)) // 30 seconds for long scripts
         .Build();
     await using var client = await GlideClient.CreateClient(config);
@@ -1184,14 +1206,18 @@ When a client timeout occurs, the client stops waiting for a response, but the s
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
-    using Valkey.Glide.Errors;
+    using static Valkey.Glide.Errors;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
 
     // Handle cluster routing errors
+    using var script = new Script("return redis.call('MGET', KEYS[1], KEYS[2])");
     try
     {
-        var result = await clusterClient.ScriptInvokeAsync(script,
-            new ScriptOptions()
-                .WithKeys("key1", "key2")); // Might be in different slots
+        var options = new ScriptOptions().WithKeys("key1", "key2"); // Might be in different slots
+        var result = await clusterClient.ScriptInvokeAsync(script, options);
     }
     catch (RequestException e) when (e.Message.Contains("CROSSSLOT"))
     {
@@ -1345,6 +1371,10 @@ When a client timeout occurs, the client stops waiting for a response, but the s
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
 
     // Good: Conditional update with multiple data structures
     using var conditionalUpdate = new Script(@"
@@ -1665,6 +1695,10 @@ When a client timeout occurs, the client stops waiting for a response, but the s
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
 
     // Good: Use hash tags for related keys
     using var clusterScript = new Script(@"


### PR DESCRIPTION
### Summary

Add automated compilation validation for C# code examples in documentation MDX files:

- A Python script extracts `csharp` fenced code blocks, passes them to the existing `validate_examples.py` from `valkey-glide-csharp`, and reports compilation failures.
- A GitHub Actions workflow runs this on every PR. 
- All existing C# examples have been fixed to compile.

### Issue link

Closes #193

### Content Changes

- New `scripts/check_csharp_examples.py` — extracts C# examples from MDX files using regex, writes them to a temp JSON file, invokes the valkey-glide-csharp validator, and cleans up. Accepts `--validator` and `--glide-dll` flags.
- New `.github/workflows/check-csharp-examples.yml` — CI workflow that downloads the Valkey.Glide DLL from NuGet and the validator script from GitHub, then runs the check on PRs targeting `main`.
- Updated `.gitignore` with Python bytecode entries.
- Fixed C# examples across 15 MDX files to be fully self-contained (imports, client creation, compilable code).
- Changed non-compilable API signature blocks from `csharp` to `text` fences.
- Consolidated step-by-step code fragments into single full examples where fragments couldn't compile independently.

### Implementation

- The extraction uses a single multiline regex (`re.MULTILINE | re.DOTALL`) to match `csharp` fenced blocks, allowing leading whitespace for blocks nested inside MDX `<TabItem>` components.
- The script creates a temp JSON file, invokes the validator as a subprocess, and cleans up in a `finally` block.
- Before running, the script verifies the validator is executable by running `--help`.
- The CI workflow avoids checking out or building the full valkey-glide-csharp repo — it downloads only the DLL (from NuGet) and the validator script (from GitHub raw).
- All C# examples now include `using Valkey.Glide;`, `using static Valkey.Glide.ConnectionConfiguration;`, and create a client via `new StandaloneClientConfigurationBuilder().Build()` or `new ClusterClientConfigurationBuilder().Build()`.

### Testing

- `pnpm build` passes (104 pages, all internal links valid).
- `pnpm format` passes with no new warnings.
- `python3 scripts/check_csharp_examples.py --validator ... --glide-dll ...` validates all 79 C# examples successfully.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.