### PR TITLE
Update jedis-compatibility migration guide for no-classifier JAR

### DIFF
--- a/src/content/docs/migration/java/jedis/jedis-compatibility-layer/instructions.mdx
+++ b/src/content/docs/migration/java/jedis/jedis-compatibility-layer/instructions.mdx
@@ -14,19 +14,32 @@ This section outlines the steps and strategies for migrating to the Valkey GLIDE
 
 The migration can be done by simply replacing the `jedis` dependency with `valkey-glide-jedis-compatibility`.
 
+<Aside type="tip" title="No classifier needed">
+  Starting with version 2.4.0, `valkey-glide-jedis-compatibility` is a pure-Java JAR. You no longer need to specify a platform classifier — the native libraries are resolved transitively through the `valkey-glide` uber JAR dependency in the POM.
+
+  Platform-specific classifier JARs are still published for backward compatibility. They contain the same pure-Java code as the no-classifier JAR.
+</Aside>
+
 <Tabs>
   <TabItem label="Gradle">
     ```diff lang="groovy"
     dependencies {
     -    implementation 'redis.clients:jedis:5.1.5'
-    +    implementation group: 'io.valkey', name: 'valkey-glide-jedis-compatibility', version: '2.+', classifier: 'osx-aarch_64'
+    +    implementation group: 'io.valkey', name: 'valkey-glide-jedis-compatibility', version: '2.+'
     }
     ```
   </TabItem>
 
   <TabItem label="Maven">
-    ```xml
-    # TODO: Add Maven example
+    ```diff lang="xml"
+    <dependency>
+    -    <groupId>redis.clients</groupId>
+    -    <artifactId>jedis</artifactId>
+    -    <version>5.1.5</version>
+    +    <groupId>io.valkey</groupId>
+    +    <artifactId>valkey-glide-jedis-compatibility</artifactId>
+    +    <version>2.4.0</version>
+    </dependency>
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

Update the Jedis compatibility layer migration guide to reflect that `valkey-glide-jedis-compatibility` is now a pure-Java JAR and no longer requires a platform classifier (starting in v2.4.0).

### Issue link

This Pull Request is linked to issue (URL): 

### Content Changes

- **Updated page:** `src/content/docs/migration/java/jedis/jedis-compatibility-layer/instructions.mdx`

| Change | Details |
|--------|---------|
| Gradle example | Removed platform classifier (`classifier: 'osx-aarch_64'`) from the dependency declaration |
| Maven example | Replaced `# TODO: Add Maven example` placeholder with a proper diff showing migration from `redis.clients:jedis` to `io.valkey:valkey-glide-jedis-compatibility` |
| Tip callout | Added callout explaining that no classifier is needed from v2.4.0 |
| Backward compatibility note | Noted that classifier JARs are still published for backward compatibility with identical functionality |

### Implementation

- Updated the Gradle dependency diff to use the no-classifier form: `implementation group: 'io.valkey', name: 'valkey-glide-jedis-compatibility', version: '2.+'`
- Added a complete Maven dependency diff showing the migration from Jedis to the compatibility layer with version `2.4.0`
- Added an `<Aside type="tip">` callout at the top of the Instructions section explaining the no-classifier change and backward compatibility of classifier JARs

### Testing

n/a

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] All commits are signed off with `--signoff` flag.
- [ ] `pnpm build` runs successfully.
- [ ] Links have been checked for validity.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
