### PR TITLE
docs(lettuce): Fix stale 'lazyConnect not supported' entry

### DIFF
--- a/src/content/docs/migration/java/lettuce/connection-setup.mdx
+++ b/src/content/docs/migration/java/lettuce/connection-setup.mdx
@@ -202,7 +202,7 @@ The table below compares **Lettuce constructors** with **Glide configuration par
 | `withTimeout(Duration.ofMillis(500))` | `requestTimeout(500)` |
 | `ReadFrom.REPLICA` | `readFrom(ReadFrom.REPLICA)` / `readFrom(ReadFrom.PREFER_REPLICA)` / `readFrom(ReadFrom.AZ_AFFINITY)` / `readFrom(ReadFrom.AZ_AFFINITY_REPLICAS_AND_PRIMARY)` [Read about AZ affinity](https://valkey.io/blog/az-affinity-strategy/) |
 | `SocketOptions.builder().connectTimeout()` | `connectionBackoff(ConnectionBackoffStrategy.builder().numberOfRetries(retries).build())` |
-| `lazyConnect: boolean` | Not suppoerted yet |
+| `lazyConnect: boolean` | `lazyConnect(true)` — see [Configure Lazy Connection](/how-to/connections/configure-lazy-connection/) for usage and trade-offs. |
 
 **Advanced configuration**
 


### PR DESCRIPTION
### Summary

The Lettuce migration guide's "Constructor Parameters Comparison" table had a row claiming `lazyConnect` is "Not suppoerted yet" — a typo, and factually stale. GLIDE supports `lazyConnect` across every language and has a dedicated [Configure Lazy Connection](https://glide.valkey.io/how-to/connections/configure-lazy-connection/) how-to. This PR replaces the broken row with a pointer to that page.

### Issue link

N/A — drive-by fix surfaced while cross-checking docs against the source for a customer question.

### Content Changes

One line in `src/content/docs/migration/java/lettuce/connection-setup.mdx`:

| Before | After |
| --- | --- |
| `lazyConnect: boolean` → Not suppoerted yet | `lazyConnect: boolean` → `lazyConnect(true)` — see [Configure Lazy Connection](/how-to/connections/configure-lazy-connection/) for usage and trade-offs. |

### Implementation

Pure markdown-table edit — no sidebar or structural changes.

### Testing

- `pnpm build` — succeeds, 104 pages.
- Internal link validator passes (the new `/how-to/connections/configure-lazy-connection/` link resolves).
- `pnpm format` — no changes to this file.

### Checklist

- [ ] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
