### PR TITLE
docs: Add C# examples for Search and JSON module documentation

### DIFF
--- a/src/content/docs/concepts/client-features/modules.mdx
+++ b/src/content/docs/concepts/client-features/modules.mdx
@@ -33,10 +33,10 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
 
 Below are the supported Valkey Modules and their minimum required GLIDE client versions:
 
-| Module     | Python | Node | Java | Go   | C#  | PHP |
-| ---------- | ------ | ---- | ---- | ---- | --- | --- |
-| **JSON**   | 0.3+   | 1.2+ | 1.2+ | 2.4+ | N/A | N/A |
-| **SEARCH** | 1.2+   | 1.2+ | 1.2+ | 2.4+ | N/A | N/A |
+| Module     | Python | Node | Java | Go   | C#   | PHP |
+| ---------- | ------ | ---- | ---- | ---- | ---- | --- |
+| **JSON**   | 0.3+   | 1.2+ | 1.2+ | 2.4+ | 1.1+ | N/A |
+| **SEARCH** | 1.2+   | 1.2+ | 1.2+ | 2.4+ | 1.1+ | N/A |
 
 ## What's Next
 

--- a/src/content/docs/how-to/modules-api/json-module.mdx
+++ b/src/content/docs/how-to/modules-api/json-module.mdx
@@ -159,7 +159,9 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
     using Valkey.Glide.ServerModules;
 
     // Both standalone and cluster mode are supported
-    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder().Build();
+    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .Build();
     await using var client = await GlideClient.CreateClient(config);
 
     var key = "testKey";

--- a/src/content/docs/how-to/modules-api/json-module.mdx
+++ b/src/content/docs/how-to/modules-api/json-module.mdx
@@ -154,9 +154,25 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
   </TabItem>
 
   <TabItem label="C#">
-    :::note
-    The Modules API is not yet available in GLIDE C#.
-    :::
+    ```csharp
+    using Valkey.Glide;
+    using Valkey.Glide.ServerModules;
+
+    // Both standalone and cluster mode are supported
+    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var key = "testKey";
+    var path = "$";
+    var jsonValue = """{"a": 1.0, "b": 2}""";
+
+    // JSON.SET
+    await GlideJson.SetAsync(client, key, path, jsonValue);
+
+    // JSON.GET
+    var response = await GlideJson.GetAsync(client, key);
+    Console.WriteLine($"Output: {response}");  // Output: {"a":1.0,"b":2}
+    ```
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/how-to/modules-api/search-module.mdx
+++ b/src/content/docs/how-to/modules-api/search-module.mdx
@@ -308,7 +308,9 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
     using Valkey.Glide.ServerModules;
 
     // Both standalone and cluster mode are supported
-    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder().Build();
+    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .Build();
     await using var client = await GlideClient.CreateClient(config);
 
     var prefix = "{hash}:";
@@ -335,11 +337,11 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
     // Insert hash data with vector fields (2-dimensional float32 vectors = 8 bytes each)
     var vec0 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
     var vec1 = new byte[] { 0, 0, 0, 0, 0, 0, 0x80, 0xBF };
-    await client.HashSetAsync($"{prefix}0", [new("vec", vec0)]);
-    await client.HashSetAsync($"{prefix}1", [new("vec", vec1)]);
+    await client.HashSetAsync($"{prefix}0", "vec", vec0);
+    await client.HashSetAsync($"{prefix}1", "vec", vec1);
 
     // Let server digest the data and update index
-    await Task.Delay(TimeSpan.Seconds(1));
+    await Task.Delay(TimeSpan.FromSeconds(1));
 
     // FT.SEARCH
     var query = "*=>[KNN 2 @VEC $query_vec]";
@@ -351,9 +353,9 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
         },
     };
     var result = await Ft.SearchAsync(client, index, query, searchOptions);
-    var vectors = result.Documents.Select(d => Convert.ToHexString(d.Fields["vec"].ToByteArray()));
-    
-    Console.WriteLine("$Total results: {result.TotalResults}");     // Total results: 2
+    var vectors = result.Documents.Select(d => Convert.ToHexString((byte[])d.Fields["vec"]));
+
+    Console.WriteLine($"Total results: {result.TotalResults}");     // Total results: 2
     Console.WriteLine($"Vectors: [{string.Join(", ", vectors)}]");  // Vectors: [0000000000000000, 00000000000080BF]
     ```
   </TabItem>

--- a/src/content/docs/how-to/modules-api/search-module.mdx
+++ b/src/content/docs/how-to/modules-api/search-module.mdx
@@ -303,9 +303,59 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
   </TabItem>
 
   <TabItem label="C#">
-    :::note
-    The Modules API is not yet available in GLIDE C#.
-    :::
+    ```csharp
+    using Valkey.Glide;
+    using Valkey.Glide.ServerModules;
+
+    // Both standalone and cluster mode are supported
+    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder().Build();
+    await using var client = await GlideClient.CreateClient(config);
+
+    var prefix = "{hash}:";
+    var index = prefix + "index";
+
+    // FT.CREATE a Hash index with a vector field
+    var fields = new Ft.CreateField[]
+    {
+        new Ft.CreateVectorFieldHnsw
+        {
+            Identifier = "vec",
+            Alias = "VEC",
+            Dimensions = 2,
+            DistanceMetric = Ft.DistanceMetric.Euclidean,
+        },
+    };
+    var createOptions = new Ft.CreateOptions
+    {
+        DataType = Ft.DataType.Hash,
+        Prefixes = [prefix],
+    };
+    await Ft.CreateAsync(client, index, fields, createOptions);
+
+    // Insert hash data with vector fields (2-dimensional float32 vectors = 8 bytes each)
+    var vec0 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+    var vec1 = new byte[] { 0, 0, 0, 0, 0, 0, 0x80, 0xBF };
+    await client.HashSetAsync($"{prefix}0", [new("vec", vec0)]);
+    await client.HashSetAsync($"{prefix}1", [new("vec", vec1)]);
+
+    // Let server digest the data and update index
+    await Task.Delay(TimeSpan.Seconds(1));
+
+    // FT.SEARCH
+    var query = "*=>[KNN 2 @VEC $query_vec]";
+    var searchOptions = new Ft.SearchOptions
+    {
+        Params = new Dictionary<ValkeyValue, ValkeyValue>
+        {
+            ["query_vec"] = vec0,
+        },
+    };
+    var result = await Ft.SearchAsync(client, index, query, searchOptions);
+    var vectors = result.Documents.Select(d => Convert.ToHexString(d.Fields["vec"].ToByteArray()));
+    
+    Console.WriteLine("$Total results: {result.TotalResults}");     // Total results: 2
+    Console.WriteLine($"Vectors: [{string.Join(", ", vectors)}]");  // Vectors: [0000000000000000, 00000000000080BF]
+    ```
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/how-to/security/iam-integration.mdx
+++ b/src/content/docs/how-to/security/iam-integration.mdx
@@ -26,10 +26,10 @@ For GLIDE versions below 2.2, see the [guide](/how-to/security/iam-integration-u
 2. **Required Information**:
 
 * **username**: Your ElastiCache/MemoryDB username
-* **cluster_name**: Your cluster's name
+* **cluster\_name**: Your cluster's name
 * **service**: Either **ElastiCache** or **MemoryDB**
 * **region**: The AWS region where your cluster runs
-* **refresh_interval_seconds (Optional)**: How often to refresh the token. Default is **300 seconds (5 minutes)**
+* **refresh\_interval\_seconds (Optional)**: How often to refresh the token. Default is **300 seconds (5 minutes)**
 
 ## Examples
 


### PR DESCRIPTION
### Summary

Add C# code examples for the Search and JSON modules.

### Issue link

Closes https://github.com/valkey-io/valkey-glide-docs/issues/197

### Content Changes

- Replaced the "Modules API is not yet available in GLIDE C#" placeholder in the Search and JSON modules docs with a complete C# examples.
- Updated the Modules API version requirements table to show C# 1.1+ support for both JSON and SEARCH modules.

### Implementation

The C# examples use the `Valkey.Glide.ServerModules` namespace from the [`valkey-glide-csharp`](https://github.com/valkey-io/valkey-glide-csharp) repository. Both examples follow the same patterns as the existing language tabs (Java, Node, Python, Go, PHP).

### Testing

- `pnpm build` passes successfully (104 pages built, all internal links valid).
- `pnpm format` applied with no issues on the modified files.
- C# examples check passes

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.