### PR TITLE
docs(client-side-caching): clarify TTL-only limits and managed-service compatibility

### DIFF
--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -390,7 +390,7 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 
 ### Compatibility with managed services
 
-When server-driven invalidation lands in a future GLIDE release, it will rely on Valkey's [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) subcommand. Not every deployment exposes that command. The table below summarizes where the feature will be available once it ships:
+GLIDE does not currently support the `CLIENT TRACKING` command. When server-driven invalidation lands in a future release, it will rely on Valkey's [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) subcommand. Not every deployment exposes that command. The table below summarizes where the feature will be available once it ships:
 
 | Deployment                                                          | Exposes `CLIENT TRACKING`? | Notes                                                                                                                                                                                                                                                       |
 | ------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 Client-side caching in Valkey GLIDE stores responses from cacheable read commands in a local in-memory cache on the client, reducing network round-trips and server load. When a cached command is issued again, the response is served directly from local memory without contacting the server.
 
 <Aside type="caution" title="TTL-Only Caching">
-  The current implementation uses **TTL-based expiration only**. There is no server-side invalidation — cached entries may become stale before their TTL expires if the underlying data changes on the server. Server-side tracking-based invalidation will be added in a future release.
+  The current implementation uses **TTL-based expiration only**. There is no server-side invalidation — cached entries may become stale before their TTL expires if **any client** modifies the underlying data, **including the same client that cached the value**. A read issued immediately after the same client's `SET` / `HSET` / `SADD` / `DEL` will still return the cached value until its TTL expires. Server-side tracking-based invalidation (using the [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) protocol) will be added in a future release.
 </Aside>
 
 ## How It Works
@@ -386,12 +386,49 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 | **Lazy expiration** | Expired entries are cleaned up on access, not proactively in the background. |
 | **Limited command coverage** | Only `GET`, `HGETALL`, and `SMEMBERS` are cached. Other read commands are not cached. |
 | **NIL not cached** | If a key does not exist, the nil response is not stored. |
-| **No invalidation on writes** | Writing to a key (e.g., `SET`) does not automatically invalidate the local cache entry for that key. |
+| **No invalidation on writes** | Writing to a key (e.g., `SET`, `HSET`, `SADD`, `DEL`) does not invalidate the local cache entry — even when the write is issued by the same client that has the value cached. Subsequent reads return the stale value until its TTL expires or it is evicted under memory pressure. |
+
+### Compatibility with managed services
+
+When server-driven invalidation lands in a future GLIDE release, it will rely on Valkey's [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) subcommand. Not every deployment exposes that command. The table below summarizes where the feature will be available once it ships:
+
+| Deployment                                                          | Exposes `CLIENT TRACKING`? | Notes                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Self-managed Valkey or Redis OSS                                    | ✅ Yes                     | Requires Valkey 7.2+ / Redis OSS 6.0+ (any version that supports `CLIENT TRACKING`).                                                                                                                                                                        |
+| Amazon MemoryDB                                                     | ✅ Yes                     | Standard `CLIENT` surface available.                                                                                                                                                                                                                        |
+| Amazon ElastiCache (cluster-mode replication group, non-serverless) | ✅ Yes                     | Standard `CLIENT` surface available.                                                                                                                                                                                                                        |
+| Amazon ElastiCache **Serverless**                                   | ❌ No                      | Only `CLIENT GETNAME / SETNAME / REPLY / HELP` are exposed; `CLIENT TRACKING` returns `ERR unknown subcommand 'tracking'`. The TTL-only behavior described above will continue to apply on Serverless even after server-driven invalidation lands in GLIDE. |
+
+If your deployment is in the last row, plan around the TTL-only model: cache only data that is immutable or can tolerate staleness up to its TTL.
+
+## Validating cache behavior
+
+The metrics counters give you an objective way to confirm caching is doing what you expect. The following sequence is short enough to run interactively from a single client with `enableMetrics(true)` set, and illustrates the most common behaviors:
+
+| Step | Operation           | What you should see                                                                                                                                       |
+| ---- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | `SET k v1`          | Server-only. Cache state unchanged.                                                                                                                       |
+| 2    | `GET k`             | Cache **miss**, populates the entry. `entryCount=1`, `totalLookups=1`, `hitRate≈0`.                                                                       |
+| 3    | `GET k`             | Cache **hit**. `totalLookups=2`, `hitRate≈0.5`.                                                                                                           |
+| 4    | `GET nonexistent`   | Cache miss; the `nil` reply is **not** cached. `entryCount` stays at `1`, `missRate` rises.                                                               |
+| 5    | `SET k v2`          | Server-only. **The cache still holds `v1`** — no invalidation, even though the same client just wrote.                                                   |
+| 6    | `GET k`             | Returns `v1` — the stale cached value. The cache catches up only after the entry's TTL expires or the entry is evicted under memory pressure.            |
+
+### Confirming the limit on the same client
+
+The biggest surprise for new users is that the cache does **not** clear after the *same* client writes a key it had cached. You can confirm this with a single client and four operations:
+
+1. `SET k "before"`
+2. `GET k` (populates the cache).
+3. `SET k "after"` (writes go through to the server; the cache is untouched).
+4. `GET k` → returns `"before"` until the entry's TTL expires.
+
+This is the expected behavior of the TTL-only implementation. Until server-driven invalidation lands, treat any key the application writes to as **not safely cacheable**, regardless of which client performs the write.
 
 ## Best Practices
 
 * **Set an appropriate TTL** — Choose a TTL that balances freshness with cache effectiveness. Shorter TTLs reduce staleness risk; longer TTLs improve hit rates.
 * **Size the cache appropriately** — Monitor eviction counts. High eviction rates indicate the cache is too small for the working set.
 * **Use metrics to tune** — Enable metrics during development and load testing to understand cache behavior and optimize configuration.
-* **Consider data volatility** — Client-side caching works best for data that changes infrequently relative to how often it is read. Rapidly changing data will produce stale reads.
+* **Use only for read-heavy, slow-changing data** — Until server-driven invalidation ships, restrict the cache to values that can tolerate staleness up to your TTL: configuration, lookup tables, slow-changing reference data, computed projections rebuilt out-of-band, and similar. Avoid caching any key that the application itself writes to during its lifetime — reads after the write will return stale data.
 * **Avoid sharing caches across databases** — Keys in different databases may have the same name but different values.


### PR DESCRIPTION
### Summary

Clarify the existing `Client-Side Caching` concept page so that the consequences of the TTL-only behavior are unambiguous, and add a small "Validating cache behavior" worked example that lets readers self-confirm what the cache does (and where it won't help them) without writing test code first.

The page already states that there is no server-side invalidation; this PR sharpens the consequences readers most often miss in practice — particularly that **the same client's own writes also leave the cache stale** — and adds a managed-service compatibility note specific to AWS ElastiCache Serverless.

### Issue link

This Pull Request is linked to issue (URL): _none — small documentation clarification_

### Content Changes

Single file: `src/content/docs/concepts/client-features/client-side-caching.mdx`. 40 lines added, 3 lines replaced.

1. **Top "TTL-Only Caching" Aside** — extend to call out that *any* client (including the same client doing the read) modifying the data leaves cached entries stale until TTL. Link to the upstream `CLIENT TRACKING` reference.
2. **Limitations table → "No invalidation on writes" row** — broaden the command list (`SET / HSET / SADD / DEL`), make the same-client case explicit, and state the staleness window (until TTL or eviction).
3. **New `### Compatibility with managed services` subsection** under Limitations — small table covering self-managed Valkey/Redis OSS, Amazon MemoryDB, ElastiCache cluster-mode replication groups (non-serverless), and ElastiCache **Serverless**, calling out that Serverless rejects `CLIENT TRACKING` so the TTL-only model will continue to apply on Serverless even after Phase 2 ships.
4. **New `## Validating cache behavior` section** before Best Practices — a 6-row worked sequence with expected metric values per step, plus a focused "Confirming the limit on the same client" sub-block that gives readers a 4-step reproduction of the most common footgun (own-write returning stale).
5. **Best Practices "Consider data volatility" bullet** — tightened from a soft "works best for slow-changing data" to a hard "do not cache any key the application writes to."

### Implementation

All claims about command surface (e.g. that ElastiCache Serverless rejects `CLIENT TRACKING` with `ERR unknown subcommand 'tracking'`) were verified empirically against:

- A live Amazon ElastiCache Serverless cache (Valkey 8) over TLS — confirmed only `CLIENT GETNAME / SETNAME / REPLY / HELP` are exposed.
- A live Amazon ElastiCache cluster-mode-enabled replication group (Valkey 8) over TLS — confirmed `CLIENT TRACKING ON` returns `OK` and `CLIENT TRACKINGINFO` reports `flags on`.

The worked sequence in `## Validating cache behavior` describes exactly what an interactive session against GLIDE 2.4.0 produces today; no synthetic numbers.

Reviewers may want to look most closely at:

- The wording of the new "No invalidation on writes" row, since it grew significantly. The intent is to be precise without pre-empting the upcoming Phase 2 release notes.
- The compatibility table — happy to drop the AWS-specific entries if that level of vendor specificity isn't preferred for this page; I left them in because Serverless is where readers most often hit the surprise.

### Testing

- `pnpm install` — clean.
- `pnpm format` — clean for the modified file (the unrelated remark-lint warnings in `pubsub-basics.mdx` and `tutorials/tls.mdx` already existed on `main`).
- `pnpm build` — clean. 107 pages built, all internal links valid, sitemap regenerated.
- Visual review of the rendered page locally with `pnpm dev` — tables render, anchors work, edit-on-GitHub link resolves correctly.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue (or scoped to one focused change).
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct — `main`.
- [x] Squash on merge (single-commit clarification PR).
