### PR TITLE
ci: harden network calls against transient registry flakes

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -28,7 +28,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --fetch-retries=5 --fetch-retry-maxtimeout=120000
 
       - name: Check formatting
         run: pnpm format:check

--- a/doc-gen/build-node-docs.sh
+++ b/doc-gen/build-node-docs.sh
@@ -20,7 +20,7 @@ if [ ! -d "$NODE_CLIENT_DIR" ]; then
 fi
 
 cd "$NODE_CLIENT_DIR"
-npm install typedoc
+npm install --fetch-retries=5 --fetch-retry-maxtimeout=120000 typedoc
 npm run build
 npx typedoc --options $SCRIPT_DIR/typedoc.json --out $OUT_LOCATION
 

--- a/doc-gen/build-python-docs.sh
+++ b/doc-gen/build-python-docs.sh
@@ -23,8 +23,8 @@ fi
 
 python3 -m venv .venv
 source .venv/bin/activate
-pip3 install --upgrade pip
-pip3 install -r $SCRIPT_DIR/requirements.txt
+pip3 install --retries 5 --timeout 120 --upgrade pip
+pip3 install --retries 5 --timeout 120 -r $SCRIPT_DIR/requirements.txt
 python3 -m mkdocs build --config-file "$SCRIPT_DIR/mkdocs.yml" --site-dir $OUT_LOCATION
 
 echo "Python client documentation generated successfully!"

--- a/doc-gen/install-deps.sh
+++ b/doc-gen/install-deps.sh
@@ -6,8 +6,8 @@
 set -e
 
 echo "Installing system dependencies..."
-sudo apt-get update -y
-sudo apt-get install -y git gcc pkg-config openssl libssl-dev unzip cmake python3 python3-pip
+sudo apt-get update -y -o Acquire::Retries=3
+sudo apt-get install -y -o Acquire::Retries=3 git gcc pkg-config openssl libssl-dev unzip cmake python3 python3-pip
 
 echo "Installing Rust..."
 # -y flag added for non-interactive installation
@@ -17,7 +17,7 @@ curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 2 https://sh.rustup
 source "$HOME/.cargo/env"
 
 echo "Installing Zig and Cargo Zigbuild..."
-pip3 install ziglang
+pip3 install --retries 5 --timeout 120 ziglang
 cargo install --locked cargo-zigbuild
 
 echo "Installing Protoc 29.1..."


### PR DESCRIPTION
### Summary

Harden CI workflows against transient network flakes by adding explicit retry and timeout flags to every package-manager and `apt` invocation in the build pipeline. Triggered by an investigation of [PR #216 CI](https://github.com/valkey-io/valkey-glide-docs/actions/runs/26171911081/job/76991685823?pr=216), where `build-java-docs` failed at `Install Dependencies → pip3 install ziglang` with:

```
pip._vendor.urllib3.exceptions.ReadTimeoutError:
  HTTPSConnectionPool(host='files.pythonhosted.org', port=443):
  Read timed out.
```

`ziglang` is a ~50 MB PyPI wheel; the default pip timeout (15 s) and zero retries make it the most fragile network call in the pipeline. A re-run of the same commit succeeded, confirming the transient nature.

### Issue link

This Pull Request is linked to issue (URL): _none — CI stability fix triggered by a flake on PR #216_

### Content Changes

Audited every workflow file in `.github/workflows/` and every script under `doc-gen/` and `scripts/` for outbound network calls. Six commands across four files lacked explicit retry/timeout configuration:

| File                                          | Before                                                                                                                | After                                                                                                                                                                                  |
| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `doc-gen/install-deps.sh` (apt update)        | `sudo apt-get update -y`                                                                                              | `sudo apt-get update -y -o Acquire::Retries=3`                                                                                                                                         |
| `doc-gen/install-deps.sh` (apt install)       | `sudo apt-get install -y …`                                                                                           | `sudo apt-get install -y -o Acquire::Retries=3 …`                                                                                                                                      |
| `doc-gen/install-deps.sh` (pip ziglang)       | `pip3 install ziglang`                                                                                                | `pip3 install --retries 5 --timeout 120 ziglang`                                                                                                                                       |
| `doc-gen/build-python-docs.sh` (pip ×2)       | `pip3 install --upgrade pip`<br>`pip3 install -r $SCRIPT_DIR/requirements.txt`                                        | `pip3 install --retries 5 --timeout 120 --upgrade pip`<br>`pip3 install --retries 5 --timeout 120 -r $SCRIPT_DIR/requirements.txt`                                                     |
| `doc-gen/build-node-docs.sh` (npm)            | `npm install typedoc`                                                                                                 | `npm install --fetch-retries=5 --fetch-retry-maxtimeout=120000 typedoc`                                                                                                                |
| `.github/workflows/static-checks.yml` (pnpm)  | `pnpm install --frozen-lockfile`                                                                                      | `pnpm install --frozen-lockfile --fetch-retries=5 --fetch-retry-maxtimeout=120000`                                                                                                     |

The values are aligned across tools so behavior is consistent: 5 retries, 120 seconds maximum read timeout per attempt.

Why these specific flags:

- **`pip --retries 5 --timeout 120`** — pip's default is `--retries 5` (since pip 24.x) but `--timeout 15`; the timeout, not the retry count, is what bites here. Bumping to 120 s tolerates slow PyPI CDN responses.
- **`apt-get … -o Acquire::Retries=3`** — apt's default is 0; setting `Acquire::Retries=3` is the documented way to tolerate Ubuntu/Debian mirror blips.
- **`npm --fetch-retries=5 --fetch-retry-maxtimeout=120000`** / **`pnpm --fetch-retries=5 --fetch-retry-maxtimeout=120000`** — both default to `fetch-retries=2` and `fetch-retry-maxtimeout=60000`. Bumping to 5/120 s aligns with the pip configuration so a registry hiccup doesn't fail the whole job.

### Audit results — what was left intentionally unchanged

| Where                                                                                                                                            | Why                                                                                                                                |
| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
| `curl … rustup.rs` and `curl … protocolbuffers/protobuf` in `install-deps.sh`                                                                    | Already use `--retry 3 --retry-delay 2`.                                                                                           |
| `cargo install --locked cargo-zigbuild` in `install-deps.sh`                                                                                     | Cargo has built-in HTTP retries with exponential backoff for crates.io fetches. Adding flags here would only obscure failures.     |
| `git clone --filter=blob:none …` in `ci-cd.yml` (`get-release-tag`)                                                                              | Fetches GitHub's own CDN; almost never flakes. Adding retries would mask real GitHub-side outages.                                 |
| `dotnet build` in `check-csharp-examples.yml`                                                                                                    | NuGet has built-in retries (default 3 with exponential backoff). No change needed.                                                 |
| Managed actions: `actions/checkout@v4`, `actions/setup-{java,node,python,dotnet}@v*`, `actions/{upload,download}-artifact@v4`, `actions/deploy-pages@v4`, `withastro/action@v4`, `lycheeverse/lychee-action@v2.8.0`, `pnpm/action-setup@v4` | All have managed retry behavior built in.                                                                                          |

### Implementation

- All flag names verified against current CLI documentation:
  - pip: `--retries`, `--timeout` ([pip CLI reference](https://pip.pypa.io/en/stable/cli/pip_install/)).
  - apt: `Acquire::Retries=N` ([apt-transport configuration](https://manpages.debian.org/bookworm/apt/apt-transport-http.1.en.html)).
  - npm: `--fetch-retries`, `--fetch-retry-maxtimeout` ([npm config](https://docs.npmjs.com/cli/v10/using-npm/config#fetch-retries)).
  - pnpm: same flag names ([pnpm settings](https://pnpm.io/settings#fetch-retries)).
- No CI workflow YAML structure changed; only the shell command on one line was modified.
- No content under `src/` was touched; all `pip install` / `npm install` / etc. inside `.mdx` files are user-facing installation instructions and were left as-is for readability.

### Testing

- `bash -n` on every modified shell script — no syntax errors.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/static-checks.yml'))"` — valid YAML.
- `pnpm format` — clean for changed files.
- `pnpm build` — clean. 107 pages, all internal links valid.
- Behavioral validation (manual): `pip3 install --retries 5 --timeout 120 --help`, `npm install --fetch-retries=5 --help`, `pnpm install --fetch-retries=5 --help`, `sudo apt-get install -o Acquire::Retries=3 --help` — all flags accepted by the respective CLIs available on `ubuntu-latest` (Ubuntu 22.04 / 24.04).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is scoped to one focused change (CI stability).
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct — `main`.
- [x] Squash on merge.
