### PR TITLE
docs: add PHP Search module support to modules table

### DIFF
--- a/src/content/docs/concepts/client-features/modules.mdx
+++ b/src/content/docs/concepts/client-features/modules.mdx
@@ -36,7 +36,7 @@ Below are the supported Valkey Modules and their minimum required GLIDE client v
 | Module     | Python | Node | Java | Go   | C#   | PHP |
 | ---------- | ------ | ---- | ---- | ---- | ---- | --- |
 | **JSON**   | 0.3+   | 1.2+ | 1.2+ | 2.4+ | 1.1+ | N/A |
-| **SEARCH** | 1.2+   | 1.2+ | 1.2+ | 2.4+ | 1.1+ | N/A |
+| **SEARCH** | 1.2+   | 1.2+ | 1.2+ | 2.4+ | 1.1+ | 1.0+ |
 
 ## What's Next
 


### PR DESCRIPTION
## Summary

Mark PHP Valkey Search module support as available (1.0+) in the modules compatibility table.

## Source Commits

- [`493fb83`](https://github.com/valkey-io/valkey-glide-php/commit/493fb83677e9de55a5085508fe7809c8936aab99) — feat(php): Add Core Valkey Search commands.

## Changes

- Updated `modules.mdx` compatibility table: PHP Search column changed from "N/A" to "1.0+"

## Context

The PHP client now implements all core FT.* commands (ftCreate, ftDropIndex, ftList, ftSearch, ftInfo, ftAggregate, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList) via builder-pattern APIs. The search-module.mdx examples page already has a correct PHP tab with usage examples, so only the support matrix needed updating.

cc @edlng

---

*This PR was generated by the doc-trigger pipeline.*