### PR TITLE
docs: update SAVE, BGSAVE, BGREWRITEAOF command progress

### DIFF
--- a/src/content/docs/reference/valkey-commands-implementation-progress.mdx
+++ b/src/content/docs/reference/valkey-commands-implementation-progress.mdx
@@ -74,7 +74,9 @@ import { Aside } from '@astrojs/starlight/components';
 | zrangebyscore            | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | zremrangebyscore         | Done             | Done             | Done             | Done             | Done             | Done      |
 | setnx                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
-| bgsave                   | Not needed       | Not needed       | Not needed       | Not needed       | Not needed       | Not needed       |
+| bgsave                   | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
+| save                     | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
+| bgrewriteaof             | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
 | setex                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | zadd                     | Done             | Done             | Done             | Done             | Done             | Done      |
 | zrem                     | Done             | Done             | Done             | Done             | Done             | Done      |

--- a/src/content/docs/reference/valkey-commands-implementation-progress.mdx
+++ b/src/content/docs/reference/valkey-commands-implementation-progress.mdx
@@ -74,9 +74,9 @@ import { Aside } from '@astrojs/starlight/components';
 | zrangebyscore            | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | zremrangebyscore         | Done             | Done             | Done             | Done             | Done             | Done      |
 | setnx                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
-| bgsave                   | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
-| save                     | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
-| bgrewriteaof             | Not started      | Not started      | Done             | Not started      | Not started      | Not started      |
+| bgsave                   | Done             | Done             | Done             | Not started      | Done             | Done             |
+| save                     | Done             | Done             | Done             | Not started      | Done             | Done             |
+| bgrewriteaof             | Done             | Done             | Done             | Not started      | Done             | Done             |
 | setex                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | zadd                     | Done             | Done             | Done             | Done             | Done             | Done      |
 | zrem                     | Done             | Done             | Done             | Done             | Done             | Done      |


### PR DESCRIPTION
## Summary

Update command implementation progress to reflect Java, Python, Node.js, and Go client support for SAVE, BGSAVE, and BGREWRITEAOF.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`0ea0cd3`](https://github.com/valkey-io/valkey-glide/commit/0ea0cd34fa427cf843fa6c0e4e0c5ca04d9d09e8) — Java: Add support for `SAVE`, `BGSAVE`, `BGREWRITEAOF` commands (#6165)
- [`1b95d2e`](https://github.com/valkey-io/valkey-glide/commit/1b95d2e8a156359044103b0144737ae6b5d5d8c1) — Add `SAVE`, `BGSAVE`, `BGREWRITEAOF` commands (Node, Python, Go) (#6188)

## Changes

- Updated `bgsave` row: Java, Python, Node, Go, Python Sync = "Done"
- Updated `save` row: Java, Python, Node, Go, Python Sync = "Done"
- Updated `bgrewriteaof` row: Java, Python, Node, Go, Python Sync = "Done"

## Context

[PR #6165](https://github.com/valkey-io/valkey-glide/pull/6165) added Java client support and [PR #6188](https://github.com/valkey-io/valkey-glide/pull/6188) adds Python, Node.js, and Go support for `SAVE`, `BGSAVE` (with `SCHEDULE` and `CANCEL` subcommands), and `BGREWRITEAOF` on both standalone and cluster clients. Only .NET remains unimplemented.

cc @currantw

---

*This PR was generated by the automated documentation pipeline.*