### PR TITLE
docs: add PHP OPT_REPLY_LITERAL and setOption/getOption

### DIFF
--- a/src/content/docs/concepts/client-features/high-availability.mdx
+++ b/src/content/docs/concepts/client-features/high-availability.mdx
@@ -7,24 +7,24 @@ Valkey GLIDE supports high-availability features out of the box. Only minimal co
 
 ## Available HA Features
 
-- Automatic topology updates.
-- Configurable timeout and reconnect strategies.
-- Automatic command re-routing during failover.
-- Specifying a read strategy controlling how reads are distributed across the cluster.
-- Available lazy connection to nodes.
+* Automatic topology updates.
+* Configurable timeout and reconnect strategies.
+* Automatic command re-routing during failover.
+* Specifying a read strategy controlling how reads are distributed across the cluster.
+* Available lazy connection to nodes.
 
 ### Automatic Topology Updates
 
-GLIDE maintains a map of the cluster and automatically updates it when changes occur. For example, if a primary node fails and a replica is promoted, GLIDE detects this change and updates its topology mapping. 
+GLIDE maintains a map of the cluster and automatically updates it when changes occur. For example, if a primary node fails and a replica is promoted, GLIDE detects this change and updates its topology mapping.
 No additional configuration is required.
 
 ### Timeout and Reconnect Strategy
 
 GLIDE provides three configurable settings for resilience during failures:
 
-- **Request timeout** (default 250ms) — how long a command can take to complete, including retries. Consider increasing this to 1000ms to give commands time to succeed while nodes recover.
-- **Connection timeout** (default 2000ms) — how long to wait for a TCP/TLS connection to establish. Applies during initial connection and re-connections.
-- **Reconnect strategy** (exponential backoff) — To avoid retry storms, GLIDE uses an exponential backoff strategy for reconnection attempts.
+* **Request timeout** (default 250ms) — how long a command can take to complete, including retries. Consider increasing this to 1000ms to give commands time to succeed while nodes recover.
+* **Connection timeout** (default 2000ms) — how long to wait for a TCP/TLS connection to establish. Applies during initial connection and re-connections.
+* **Reconnect strategy** (exponential backoff) — To avoid retry storms, GLIDE uses an exponential backoff strategy for reconnection attempts.
 
 For more on configuring these, see our [timeouts and reconnect strategy guide](/how-to/connections/timeouts-and-reconnect-strategy/).
 
@@ -38,7 +38,7 @@ For more on how GLIDE routes commands, see our [command routing](/concepts/clien
 
 Configuring read strategies is important for high availability and latency optimization.
 
-By default, GLIDE clients read and write from the primary node. Reading from replicas provides 
+By default, GLIDE clients read and write from the primary node. Reading from replicas provides
 two benefits: reads can continue while a primary is down and it distributes load away from primaries.
 
 GLIDE also supports AZ-affinity routing, which directs reads to replicas in the same availability zone as the client, reducing cross-AZ latency.

--- a/src/content/docs/migration/php/phpredis/index.mdx
+++ b/src/content/docs/migration/php/phpredis/index.mdx
@@ -363,26 +363,54 @@ if ($client->get('nonexistent') === false) {
 
 ### 5. Configuration
 
-Configuration is done through the `connect()` method:
+Valkey GLIDE PHP supports `setOption()` and `getOption()` for runtime options, similar to PHPRedis.
+
+#### Supported Options
+
+| Option | Constant | Description |
+| --- | --- | --- |
+| Reply Literal | `ValkeyGlide::OPT_REPLY_LITERAL` | When enabled, commands that return "+OK" from Valkey return the string `"OK"` instead of `true` |
 
 <Tabs>
   <TabItem label="PHPRedis">
     ```php
-    $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
-    $redis->setOption(Redis::OPT_PREFIX, 'myapp:');
+    $redis->setOption(Redis::OPT_REPLY_LITERAL, true);
+    $result = $redis->set('key', 'value'); // Returns "OK" instead of true
     ```
   </TabItem>
 
   <TabItem label="Valkey GLIDE">
     ```php
-    $client->connect(
-        addresses: [['host' => '127.0.0.1', 'port' => 6379]],
-        request_timeout: 5000,
-        client_name: 'myapp'
-    );
+    $client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+    $result = $client->set('key', 'value'); // Returns "OK" instead of true
+
+    // Check current setting
+    $enabled = $client->getOption(ValkeyGlide::OPT_REPLY_LITERAL); // true
+
+    // Disable it
+    $client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    $result = $client->set('key', 'value'); // Returns true (default)
     ```
   </TabItem>
 </Tabs>
+
+<Aside type="note">
+  `OPT_REPLY_LITERAL` affects these commands: `SET`, `MSET`, `SETEX`, `PSETEX`, `SELECT`, `FLUSHDB`, `FLUSHALL`, `RENAME`, `RESTORE`, `CONFIG SET`, `LSET`, `LTRIM`, and `HMSET`.
+</Aside>
+
+<Aside type="caution">
+  PHPRedis options such as `OPT_SERIALIZER`, `OPT_PREFIX`, `OPT_SCAN`, and `OPT_COMPRESSION` are not currently supported. Use application-level serialization and key prefixing instead.
+</Aside>
+
+Connection configuration is done through `connect()` parameters:
+
+```php
+$client->connect(
+    addresses: [['host' => '127.0.0.1', 'port' => 6379]],
+    request_timeout: 5000,
+    client_name: 'myapp'
+);
+```
 
 ## Advanced Features
 

--- a/src/content/docs/migration/php/phpredis/index.mdx
+++ b/src/content/docs/migration/php/phpredis/index.mdx
@@ -363,54 +363,46 @@ if ($client->get('nonexistent') === false) {
 
 ### 5. Configuration
 
-Valkey GLIDE PHP supports `setOption()` and `getOption()` for runtime options, similar to PHPRedis.
-
-#### Supported Options
-
-| Option | Constant | Description |
-| --- | --- | --- |
-| Reply Literal | `ValkeyGlide::OPT_REPLY_LITERAL` | When enabled, commands that return "+OK" from Valkey return the string `"OK"` instead of `true` |
+Configuration is done through the `connect()` method:
 
 <Tabs>
   <TabItem label="PHPRedis">
     ```php
-    $redis->setOption(Redis::OPT_REPLY_LITERAL, true);
-    $result = $redis->set('key', 'value'); // Returns "OK" instead of true
+    $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
+    $redis->setOption(Redis::OPT_PREFIX, 'myapp:');
     ```
   </TabItem>
 
   <TabItem label="Valkey GLIDE">
     ```php
-    $client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
-    $result = $client->set('key', 'value'); // Returns "OK" instead of true
-
-    // Check current setting
-    $enabled = $client->getOption(ValkeyGlide::OPT_REPLY_LITERAL); // true
-
-    // Disable it
-    $client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
-    $result = $client->set('key', 'value'); // Returns true (default)
+    $client->connect(
+        addresses: [['host' => '127.0.0.1', 'port' => 6379]],
+        request_timeout: 5000,
+        client_name: 'myapp'
+    );
     ```
   </TabItem>
 </Tabs>
-
-<Aside type="note">
-  `OPT_REPLY_LITERAL` affects these commands: `SET`, `MSET`, `SETEX`, `PSETEX`, `SELECT`, `FLUSHDB`, `FLUSHALL`, `RENAME`, `RESTORE`, `CONFIG SET`, `LSET`, `LTRIM`, and `HMSET`.
-</Aside>
 
 <Aside type="caution">
   PHPRedis options such as `OPT_SERIALIZER`, `OPT_PREFIX`, `OPT_SCAN`, and `OPT_COMPRESSION` are not currently supported. Use application-level serialization and key prefixing instead.
 </Aside>
 
-Connection configuration is done through `connect()` parameters:
+#### Runtime Options
+
+Valkey GLIDE PHP supports `setOption()` and `getOption()` for the `OPT_REPLY_LITERAL` option. When enabled, commands that return "+OK" from Valkey return the string `"OK"` instead of `true`.
 
 ```php
-$client->connect(
-    addresses: [['host' => '127.0.0.1', 'port' => 6379]],
-    request_timeout: 5000,
-    client_name: 'myapp'
-);
+$client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+$result = $client->set('key', 'value'); // Returns "OK" instead of true
+
+$client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+$result = $client->set('key', 'value'); // Returns true (default)
 ```
+
+<Aside type="note">
+  `OPT_REPLY_LITERAL` affects: `SET`, `MSET`, `SETEX`, `PSETEX`, `SELECT`, `FLUSHDB`, `FLUSHALL`, `RENAME`, `RESTORE`, `CONFIG SET`, `LSET`, `LTRIM`, and `HMSET`.
+</Aside>
 
 ## Advanced Features
 

--- a/src/content/docs/migration/php/phpredis/index.mdx
+++ b/src/content/docs/migration/php/phpredis/index.mdx
@@ -361,36 +361,13 @@ if ($client->get('nonexistent') === false) {
 }
 ```
 
-### 5. Configuration
+### 5. Configuration Options
 
-Configuration is done through the `connect()` method:
+PHPRedis options such as `OPT_SERIALIZER`, `OPT_PREFIX`, `OPT_SCAN`, and `OPT_COMPRESSION` are not currently supported. Use application-level serialization and key prefixing instead.
 
-<Tabs>
-  <TabItem label="PHPRedis">
-    ```php
-    $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
-    $redis->setOption(Redis::OPT_PREFIX, 'myapp:');
-    ```
-  </TabItem>
+#### `OPT_REPLY_LITERAL` Support
 
-  <TabItem label="Valkey GLIDE">
-    ```php
-    $client->connect(
-        addresses: [['host' => '127.0.0.1', 'port' => 6379]],
-        request_timeout: 5000,
-        client_name: 'myapp'
-    );
-    ```
-  </TabItem>
-</Tabs>
-
-<Aside type="caution">
-  PHPRedis options such as `OPT_SERIALIZER`, `OPT_PREFIX`, `OPT_SCAN`, and `OPT_COMPRESSION` are not currently supported. Use application-level serialization and key prefixing instead.
-</Aside>
-
-#### Runtime Options
-
-Valkey GLIDE PHP supports `setOption()` and `getOption()` for the `OPT_REPLY_LITERAL` option. When enabled, commands that return "+OK" from Valkey return the string `"OK"` instead of `true`.
+The compatibility layer supports `OPT_REPLY_LITERAL` option. When enabled, commands that return "+OK" from Valkey return the string `"OK"` instead of `true`.
 
 ```php
 $client->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);


### PR DESCRIPTION
## Summary

Document the new `OPT_REPLY_LITERAL` option and `setOption()`/`getOption()` methods in the PHP migration guide.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`2c23ec0`](https://github.com/valkey-io/valkey-glide-php/commit/2c23ec02a9a7813414737f6670ea6de204d96d94) — feat(php): add OPT_REPLY_LITERAL option for OK response handling

## Changes

- Updated the "Configuration" section in the PHPRedis migration guide to document `setOption()`/`getOption()` with `OPT_REPLY_LITERAL`

## Context

[Php #120](https://github.com/valkey-io/valkey-glide-php/pull/120) adds PHPRedis-compatible `OPT_REPLY_LITERAL` support to both `ValkeyGlide` and `ValkeyGlideCluster`. When enabled, commands returning "+OK" from Valkey return the string "OK" instead of boolean `true`. This is the first runtime option supported via `setOption()`/`getOption()`, matching the PHPRedis API pattern.

cc @KIvanow

---

*This PR was generated by the automated documentation pipeline.*