### PR TITLE
docs: add C# client-side caching examples

### DIFF
--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -201,7 +201,7 @@ To enable client-side caching, pass a `ClientSideCache` configuration when creat
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
-    using Valkey.Glide.ConnectionConfiguration;
+    using static Valkey.Glide.ConnectionConfiguration;
 
     // Create a cache configuration
     var cache = new ClientSideCacheConfig(maxCacheKb: 1024, entryTtl: TimeSpan.FromSeconds(60))
@@ -213,14 +213,14 @@ To enable client-side caching, pass a `ClientSideCache` configuration when creat
         .WithAddress("localhost", 6379)
         .WithClientSideCache(cache)
         .Build();
-    var client = await GlideClient.CreateClientAsync(config);
+    var client = await GlideClient.CreateClient(config);
 
     // Cluster client
     var clusterConfig = new ClusterClientConfigurationBuilder()
         .WithAddress("localhost", 6379)
         .WithClientSideCache(cache)
         .Build();
-    var clusterClient = await GlideClusterClient.CreateClientAsync(clusterConfig);
+    var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
     ```
   </TabItem>
 </Tabs>
@@ -492,13 +492,13 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
         .WithAddress("localhost", 6379)
         .WithClientSideCache(cache)
         .Build();
-    var client1 = await GlideClient.CreateClientAsync(config1);
+    var client1 = await GlideClient.CreateClient(config1);
 
     var config2 = new StandaloneClientConfigurationBuilder()
         .WithAddress("localhost", 6379)
         .WithClientSideCache(cache)
         .Build();
-    var client2 = await GlideClient.CreateClientAsync(config2);
+    var client2 = await GlideClient.CreateClient(config2);
 
     // client1 populates the cache
     await client1.SetAsync("key", "value");

--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -197,6 +197,32 @@ To enable client-side caching, pass a `ClientSideCache` configuration when creat
     );
     ```
   </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using Valkey.Glide.ConnectionConfiguration;
+
+    // Create a cache configuration
+    var cache = new ClientSideCacheConfig(maxCacheKb: 1024, entryTtl: TimeSpan.FromSeconds(60))
+        .WithEvictionPolicy(EvictionPolicy.LRU)   // LRU or LFU
+        .WithMetrics(true);                       // Enable hit/miss tracking
+
+    // Standalone client
+    var config = new StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithClientSideCache(cache)
+        .Build();
+    var client = await GlideClient.CreateClientAsync(config);
+
+    // Cluster client
+    var clusterConfig = new ClusterClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithClientSideCache(cache)
+        .Build();
+    var clusterClient = await GlideClusterClient.CreateClientAsync(clusterConfig);
+    ```
+  </TabItem>
 </Tabs>
 
 ### Configuration Options
@@ -295,6 +321,21 @@ When `enableMetrics` is set to `true`, you can query cache performance statistic
     printf("Hit rate: %.2f%%\n", $hitRate * 100);
     printf("Entries: %d, Evictions: %d, Expirations: %d\n",
         $entryCount, $evictions, $expirations);
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    // Get metrics
+    double hitRate = await client.GetCacheHitRateAsync();       // 0.0–1.0
+    double missRate = await client.GetCacheMissRateAsync();     // 0.0–1.0
+    long entryCount = await client.GetCacheEntryCountAsync();
+    long evictions = await client.GetCacheEvictionsAsync();
+    long expirations = await client.GetCacheExpirationsAsync();
+    long total = await client.GetCacheTotalLookupsAsync();
+
+    Console.WriteLine($"Hit rate: {hitRate:P2}");
+    Console.WriteLine($"Entries: {entryCount}, Evictions: {evictions}, Expirations: {expirations}");
     ```
   </TabItem>
 </Tabs>
@@ -439,6 +480,32 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 
     // client2 gets a cache hit without contacting the server
     $result = $client2->get('key');  // Cache hit
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    // Both clients share the same cache
+    var cache = new ClientSideCacheConfig(maxCacheKb: 1024, entryTtl: TimeSpan.FromSeconds(60));
+
+    var config1 = new StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithClientSideCache(cache)
+        .Build();
+    var client1 = await GlideClient.CreateClientAsync(config1);
+
+    var config2 = new StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithClientSideCache(cache)
+        .Build();
+    var client2 = await GlideClient.CreateClientAsync(config2);
+
+    // client1 populates the cache
+    await client1.SetAsync("key", "value");
+    await client1.GetAsync("key");  // Cache miss — fetches from server
+
+    // client2 gets a cache hit without contacting the server
+    var result = await client2.GetAsync("key");  // Cache hit
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -326,6 +326,15 @@ When `enableMetrics` is set to `true`, you can query cache performance statistic
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithClientSideCache(new ClientSideCacheConfig(maxCacheKb: 1024, entryTtl: TimeSpan.FromSeconds(60)).WithMetrics(true))
+        .Build();
+    var client = await GlideClient.CreateClient(config);
+
     // Get metrics
     double hitRate = await client.GetCacheHitRateAsync();       // 0.0–1.0
     double missRate = await client.GetCacheMissRateAsync();     // 0.0–1.0
@@ -485,6 +494,9 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 
   <TabItem label="C#">
     ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
     // Both clients share the same cache
     var cache = new ClientSideCacheConfig(maxCacheKb: 1024, entryTtl: TimeSpan.FromSeconds(60));
 


### PR DESCRIPTION
## Summary

Add C# code examples to the client-side caching documentation page.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`e5b85d9`](https://github.com/valkey-io/valkey-glide-csharp/commit/e5b85d996c41fa34387a0e6120bed63c46aa8c86) — feat(core): add ttl based client-side cache configuration and metrics API (#330)

## Changes

- Added C# `<TabItem>` to the Configuration section showing `ClientSideCacheConfig`, `StandaloneClientConfigurationBuilder`, and `ClusterClientConfigurationBuilder`
- Added C# `<TabItem>` to the Cache Metrics section showing async metric methods (`GetCacheHitRateAsync`, `GetCacheMissRateAsync`, etc.)
- Added C# `<TabItem>` to the Shared Cache section demonstrating two clients sharing one config instance

## Context

[C# #330](https://github.com/valkey-io/valkey-glide-csharp/pull/330) adds TTL-based client-side caching to the C# GLIDE client with `ClientSideCacheConfig`, eviction policies (LRU/LFU), and cache metric methods. The existing documentation page already covered all other languages but was missing C# examples.

cc @affonsov

---

*This PR was generated by the automated documentation pipeline.*