### PR TITLE
docs: add MIGRATE command to progress tracker

### DIFF
--- a/src/content/docs/reference/valkey-commands-implementation-progress.mdx
+++ b/src/content/docs/reference/valkey-commands-implementation-progress.mdx
@@ -215,6 +215,7 @@ import { Aside } from '@astrojs/starlight/components';
 | fcall                    | Done             | Done             | Done             | Not started      | Done             | Done      |
 | zdiffstore               | Done             | Done             | Done             | Done             | Done             | Done      |
 | move                     | Done             | Done             | Done             | Done             | Done             | Done      |
+| migrate                  | Done             | Done             | Done             | Not started      | Done             | Done      |
 | geohash                  | Done             | Done             | Done             | Not started      | Done             | Done      |
 | bitpos                   | Done             | Done             | Done             | Not started      | Done             | Done      |
 | substr                   | Deprecated       | Deprecated       | Deprecated       | Deprecated       | Deprecated       | Deprecated       |


### PR DESCRIPTION
## Summary

Add the MIGRATE command to the implementation progress tracker, reflecting its current support across language clients.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`2d0d0bd`](https://github.com/valkey-io/valkey-glide/commit/2d0d0bdfe3402f44bbe2d4569dbf2dd0f68f894e) — Java: Add multi-key MIGRATE support to standalone client (#6063)
- [`d659325`](https://github.com/valkey-io/valkey-glide/commit/d659325e98eabf55cec6fa19bf5ea70758745085) — Node: Add MIGRATE KEYS (multi-key) variant (#6064)
- [`94a9661`](https://github.com/valkey-io/valkey-glide/commit/94a96619edae02e8676c2ef4f3a5a7eff5fe186a) — Python: Add MIGRATE KEYS (multi-key) variant (#6066)

## Changes

- Added `migrate` row to the command implementation progress tracker with Python, Node, Java, Go, and Python Sync marked as "Done"; .NET marked as "Not started"

## Context

[PR #6063](https://github.com/valkey-io/valkey-glide/pull/6063) adds multi-key `MIGRATE` support to the Java standalone client (`GlideClient`). [PR #6064](https://github.com/valkey-io/valkey-glide/pull/6064) adds the same multi-key `MIGRATE` support (`migrateKeys`) to the Node.js standalone client (`GlideClient`). [PR #6066](https://github.com/valkey-io/valkey-glide/pull/6066) adds `migrate_keys()` to the Python standalone client (async, sync, and batch). Single-key MIGRATE was already implemented across Python, Node.js, Java, and Go in `GenericBaseCommands`/base clients, but the command was missing from the progress tracker entirely. Multi-key MIGRATE is intentionally scoped to standalone only — it is incompatible with cluster mode due to routing limitations.

cc @affonsov

---

*This PR was generated by the automated documentation pipeline.*