### PR TITLE
docs: add Go MEMORY commands to progress tracker

### DIFF
--- a/src/content/docs/reference/valkey-commands-implementation-progress.mdx
+++ b/src/content/docs/reference/valkey-commands-implementation-progress.mdx
@@ -75,6 +75,10 @@ import { Aside } from '@astrojs/starlight/components';
 | zremrangebyscore         | Done             | Done             | Done             | Done             | Done             | Done      |
 | setnx                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | bgsave                   | Not needed       | Not needed       | Not needed       | Not needed       | Not needed       | Not needed       |
+| memory doctor            | Not started      | Not started      | Not started      | Not started      | Done             | Not started      |
+| memory malloc-stats      | Not started      | Not started      | Not started      | Not started      | Done             | Not started      |
+| memory purge             | Not started      | Not started      | Not started      | Not started      | Done             | Not started      |
+| memory stats             | Not started      | Not started      | Not started      | Not started      | Done             | Not started      |
 | setex                    | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       | deprecated       |
 | zadd                     | Done             | Done             | Done             | Done             | Done             | Done      |
 | zrem                     | Done             | Done             | Done             | Done             | Done             | Done      |


### PR DESCRIPTION
## Summary

Add MEMORY DOCTOR, MEMORY MALLOC-STATS, MEMORY PURGE, and MEMORY STATS to the command implementation progress tracker, reflecting Go client support.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`546af0b`](https://github.com/valkey-io/valkey-glide/commit/546af0b3eef6af63e2982ea287f4c136fde3b4e5) — Go: Add MEMORY DOCTOR / MEMORY MALLOC-STATS / MEMORY PURGE / MEMORY STATS commands (#5986)

## Changes

- Added `memory doctor` row with Go = "Done", others = "Not started"
- Added `memory malloc-stats` row with Go = "Done", others = "Not started"
- Added `memory purge` row with Go = "Done", others = "Not started"
- Added `memory stats` row with Go = "Done", others = "Not started"

## Context

[PR #5986](https://github.com/valkey-io/valkey-glide/pull/5986) adds `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` to the Go client for both standalone and cluster modes. These commands were not previously tracked in the progress table. Go is the first language client to implement them.

cc @sdg3iv

---

*This PR was generated by the automated documentation pipeline.*