### PR TITLE
ci: updated pipeline to handle public branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, public]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - public
 
 jobs:
   # Call the CI/CD workflow to build the site
@@ -16,7 +16,7 @@ jobs:
   # Deploy to GitHub Pages
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/public'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -2,7 +2,7 @@ name: Static Checks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, public]
   workflow_dispatch:
   workflow_call:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ When writing or editing content, place it in the correct category:
 - Internal links are validated at build time by `starlight-links-validator`
 - Use relative links for internal pages, not absolute URLs
 
+## Commit Requirements
+
+- All commits must include `--signoff` (`git commit --signoff -m "message"`) for DCO compliance
+
 # Commands
 
 Useful commands for this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,10 @@ Thank you for your interest in contributing to the Valkey GLIDE documentation!
 | `public` | Production — deploys the live site at [glide.valkey.io](https://glide.valkey.io) |
 
 In general:
+
 - Open all PRs against `main`.
 - On release day, `main` is merged onto `public` triggering a deployment.
-- Only urgent fixes are accepted directly into `public`. 
+- Only urgent fixes are accepted directly into `public`.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to Valkey GLIDE Documentation
+
+Thank you for your interest in contributing to the Valkey GLIDE documentation!
+
+## Branches Overview
+
+| Branch   | Purpose                                                                          |
+| -------- | -------------------------------------------------------------------------------- |
+| `main`   | Integration branch — all PRs target here                                         |
+| `public` | Production — deploys the live site at [glide.valkey.io](https://glide.valkey.io) |
+
+In general:
+- Open all PRs against `main`.
+- On release day, `main` is merged onto `public` triggering a deployment.
+- Only urgent fixes are accepted directly into `public`. 
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork:
+
+   ```bash
+   git clone git@github.com:<your-username>/valkey-glide-docs.git
+   cd valkey-glide-docs
+   ```
+
+3. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+4. Start the dev server:
+
+   ```bash
+   pnpm dev
+   ```
+
+## Making Changes
+
+1. Create a branch from `main`:
+
+   ```bash
+   git checkout -b your-username/short-description
+   ```
+
+2. Make your changes in `src/content/docs/`
+3. Verify your changes build correctly:
+
+   ```bash
+   pnpm build
+   ```
+
+4. Format your code:
+
+   ```bash
+   pnpm format
+   ```
+
+## Commit Guidelines
+
+All commits must be signed off to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/):
+
+```bash
+git commit --signoff -m "Your commit message"
+```
+
+## Submitting a Pull Request
+
+1. Push your branch to your fork
+2. Open a PR targeting `main`
+3. Ensure CI checks pass (build, formatting, link validation)
+4. Feel free a ping a maintainer for review.
+
+## Code Standards
+
+- Run `pnpm format` before committing
+- Run `pnpm build` to catch broken internal links
+- Use relative links for internal pages
+- Every `.mdx` file must include `title` and `description` in frontmatter
+
+## Reporting Issues
+
+For any bugs, issues, or suggestions feel free to create an issue on our Github.
+
+## AI Agent Support
+
+This project includes an [AGENTS.md](./AGENTS.md) file that provides AI coding agents with project context, architecture details, build commands, and content guidelines.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valkey GLIDE Documentation
 
-This repository host the source for the Valkey GLIDE documentation [site](https://glide.valkey.io).
+This repository hosts the source for the Valkey GLIDE documentation [site](https://glide.valkey.io).
 
 ## Technology
 
@@ -65,3 +65,8 @@ title: Your page title.
 
 Your contents follows ...
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide. Key points:
+Use [AGENTS.md](./AGENTS.md) for AI agent context.


### PR DESCRIPTION
### Summary

This PR update our pipeline to auto deploy on merges to the new `public` branch while keeping ci checks against it as well. 

- Deployment now only happens on merges to `public`. 
- `main` is now our staging branch.
- Updated `README` and `AGENTS`.
- Added `CONTRIBUTING`.