### PR TITLE
docs: add cluster-mode tuning guidance to circuit breaker guide

### DIFF
--- a/src/content/docs/how-to/connections/circuit-breaker.mdx
+++ b/src/content/docs/how-to/connections/circuit-breaker.mdx
@@ -130,7 +130,11 @@ Only transport-level failures count toward tripping the breaker:
 * Failures sending or receiving on the connection (pipeline send/receive failures)
 * Request timeouts — but only when `countTimeouts` is enabled
 
-Application and server errors do **not** count, because the request reached the server and got a valid response. For example, `WRONGTYPE`, `MOVED`, and similar command-level errors leave the breaker closed.
+Application and server errors do **not** count, because the request reached the server and got a valid response. For example, `WRONGTYPE`, `MOVED`, `CLUSTERDOWN`, and similar command-level errors leave the breaker closed.
+
+:::note
+In cluster mode, a dead or unreachable node typically produces only one initial transport error (connection drop). Subsequent requests are reclassified as timeouts while the client attempts reconnection. With the default `countTimeouts: false`, these timeouts do not feed the circuit breaker. To protect against sustained node outages in cluster mode, enable `countTimeouts: true`.
+:::
 
 ## Handling Rejections
 
@@ -237,9 +241,10 @@ All parameters are optional. The circuit breaker uses sensible defaults if you p
 * Lower `failureRateThreshold` if you want faster detection of degraded backends.
 * Increase `minErrors` in low-traffic environments to avoid false trips from small sample sizes.
 * Increase `openTimeoutMs` if your server typically takes longer to recover (e.g., failover scenarios).
-* Set `countTimeouts: true` if your timeout configuration is tight and timeouts reliably indicate a backend issue.
+* Set `countTimeouts: true` if timeouts indicate a backend issue. In cluster mode, dead nodes surface primarily as timeouts (not transport errors), so this flag is required for the circuit breaker to protect against sustained node outages.
+* In cluster mode, a single shard failure affects only ~1/N of traffic (where N is the number of shards). With the default 50% threshold, the circuit breaker will not trip for partial cluster failures. This is intentional, as healthy shards continue serving normally.
 * Keep `consecutiveSuccesses` low (2–5) for faster recovery; increase it if premature recovery causes cascading failures.
 
 :::tip
-Enable the circuit breaker with all defaults as a starting point — just pass an empty configuration object. This gives you protection with no tuning required.
+Enable the circuit breaker with all defaults as a starting point by passing an empty configuration object.
 :::

--- a/src/content/docs/how-to/connections/resilience-best-practices.mdx
+++ b/src/content/docs/how-to/connections/resilience-best-practices.mdx
@@ -170,8 +170,8 @@ See the dedicated [Circuit Breaker guide](/how-to/connections/circuit-breaker) f
 
 - Enable CB for workloads where thread exhaustion is a concern during outages.
 - The CB rejects before the request reaches the network, so rejections are near-zero-cost.
-- Enable the `countTimeouts` option (Java: `countTimeouts(true)`, Python: `count_timeouts=True`, Node/Go: `countTimeouts: true`) if your timeout configuration is tight and timeouts reliably indicate a backend issue.
-- Recovery is optimistic (allows requests through to test if the server has recovered) with guards against premature closing.
+- Enable `countTimeouts` to protect against dead or unreachable nodes. In cluster mode, dead nodes surface primarily as timeouts, so this flag is required for the CB to trip on sustained node outages.
+- Recovery is optimistic: in HalfOpen, all traffic is allowed through. After consecutive successes the breaker closes. If a failure occurs, it returns to Open.
 - When the CB rejects, handle the `CircuitBreakerException`/`CircuitBreakerError` in your application by returning a cached or degraded response, or signaling the caller to retry after a delay.
 
 ## Standalone vs Cluster


### PR DESCRIPTION
### Summary

Add cluster-mode specific tuning guidance to the circuit breaker and resilience best practices docs, based on bug bash testing results against local Valkey and ElastiCache.

### Changes

- Clarify that dead/unreachable nodes in cluster mode surface as timeouts, not transport errors
- Document that `countTimeouts: true` is required for CB protection against sustained node outages
- Add `CLUSTERDOWN` to the list of non-counting server errors
- Add guidance on partial cluster failures (1/N traffic math)
- Simplify HalfOpen recovery description
- Clean up tip box and remove redundant `countTimeouts` repetition

### Context

Bug bash testing (6 scenarios on local Valkey + 6 on ElastiCache) confirmed the CB works as designed but revealed that the default `countTimeouts: false` does not protect against dead-node scenarios in cluster mode. These doc updates ensure customers understand when and why to enable `countTimeouts: true`.