### PR TITLE
docs(go): add inflightRequestsLimit support for Go

### DIFF
--- a/src/content/docs/how-to/connections/limit-inflight-requests.mdx
+++ b/src/content/docs/how-to/connections/limit-inflight-requests.mdx
@@ -19,9 +19,11 @@ Inflight requests limit can be configured through the general client configurati
   </TabItem>
 
   <TabItem label="Go">
-    :::note
-    This feature is not yet available in GLIDE Go.
-    :::
+    ```go
+    // Limit to 1000 inflight requests per connection
+    clusterConfig := config.NewClusterClientConfiguration().
+        WithInflightRequestsLimit(1000)
+    ```
   </TabItem>
 
   <TabItem label="Java">

--- a/src/content/docs/how-to/connections/resilience-best-practices.mdx
+++ b/src/content/docs/how-to/connections/resilience-best-practices.mdx
@@ -79,6 +79,7 @@ import (
 clientConfig := config.NewClusterClientConfiguration().
     WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379}).
     WithRequestTimeout(500 * time.Millisecond).
+    WithInflightRequestsLimit(1000).
     WithClientCircuitBreaker(&config.ClientCircuitBreakerConfiguration{})
 
 client, err := glide.NewClusterClient(clientConfig)
@@ -115,7 +116,6 @@ The `inflightRequestsLimit` controls how many concurrent requests a single clien
 - If using Java with `ForkJoinPool.managedBlock()` (common in Akka, Play, or reactive frameworks), set the limit to 2-3x your thread pool size. This prevents thread explosion where `managedBlock()` spawns compensating threads faster than requests complete.
 - If you see "inflight requests limit reached" warnings in logs, either increase the limit or reduce concurrency at the application level.
 - Setting the limit too high risks memory pressure under sustained backpressure. The default of 1000 is appropriate for most workloads.
-- Note: The Go client does not yet expose `inflightRequestsLimit` configuration; the default is used.
 
 ## Thread Pool Sizing (Java)
 


### PR DESCRIPTION
### Summary

Add Go code examples for `inflightRequestsLimit` configuration and remove "not yet available" notes, now that the Go client exposes `WithInflightRequestsLimit`.

### Issue link

This Pull Request is linked to issue (URL): [Go: Expose inflightRequestsLimit configuration](https://github.com/valkey-io/valkey-glide/issues/6385)

### Content Changes

- **`limit-inflight-requests.mdx`**: Replace the "This feature is not yet available in GLIDE Go" note with a Go code snippet showing `WithInflightRequestsLimit(1000)`
- **`resilience-best-practices.mdx`**: Add `WithInflightRequestsLimit(1000)` to the existing Go tab in the recommended production configuration example, and remove the bullet noting Go doesn't support it

### Implementation

Straightforward content additions matching the existing Java/Python/Node examples on the same pages. No structural changes.

### Testing

- Verified the Go code snippet compiles and works against a live Valkey instance
- `pnpm build` passes

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.