### PR TITLE
docs(Java, Python, Node, Go): add mTLS section to Configure TLS page

### DIFF
--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -306,9 +306,17 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Insecure TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { insecure: true },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -403,9 +411,17 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Insecure TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClient } from "@valkey/valkey-glide";
+
+    const client = await GlideClient.createClient({
+        addresses: [{ host: "primary.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { insecure: true },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -272,7 +272,7 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
     client_config = GlideClusterClientConfiguration(
         addresses,
         use_tls=True,
-        advanced_configuration=advanced_config
+        advanced_config=advanced_config
     )
 
     client = await GlideClusterClient.create(client_config)
@@ -361,7 +361,7 @@ You can provide custom root certificates for TLS connections. This is useful whe
     client_config = GlideClusterClientConfiguration(
         addresses,
         use_tls=True,
-        advanced_configuration=advanced_config
+        advanced_config=advanced_config
     )
 
     client = await GlideClusterClient.create(client_config)
@@ -393,7 +393,7 @@ You can provide custom root certificates for TLS connections. This is useful whe
     client_config = GlideClientConfiguration(
         addresses,
         use_tls=True,
-        advanced_configuration=advanced_config
+        advanced_config=advanced_config
     )
 
     client = await GlideClient.create(client_config)
@@ -431,7 +431,7 @@ You can provide custom root certificates for TLS connections. This is useful whe
     client_config = GlideClusterClientConfiguration(
         addresses,
         use_tls=True,
-        advanced_configuration=advanced_config
+        advanced_config=advanced_config
     )
 
     client = await GlideClusterClient.create(client_config)

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -630,7 +630,7 @@ Byte-based mTLS is inherently static: the material is read once at connect time 
 Path-based and byte-based mTLS are mutually exclusive within a single configuration.
 Supplying both is rejected at configuration time in every SDK.
 
-A custom reload interval must be a positive whole number of seconds no greater than 2^32 - 1.
+A custom reload interval must be a positive whole number of seconds no greater than 4,294,967,295 (the maximum value of an unsigned 32-bit integer, roughly 136 years).
 Sub-second, zero, negative, and oversized values are rejected at configuration time.
 
 #### In-memory PEM (static)
@@ -1183,7 +1183,7 @@ Feed those bytes into the byte-based entry point shown above.
 
 * **mTLS still needs TLS enabled at the top level.** The advanced TLS configuration only supplies the client-side material; without TLS on the base client configuration (`use_tls=True`, `.useTLS(true)`, `useTLS: true`, or `.WithUseTLS(true)`), the client connects in plaintext and the mTLS material is not used.
 * **Path-based and byte-based mTLS are mutually exclusive.** Supplying both a certificate/key path and inline PEM bytes on the same configuration is a configuration error in every SDK.
-* **Sub-second, zero, negative, and oversized reload intervals are rejected.** The custom interval is validated at configuration time: it must be a positive whole number of seconds no greater than 2^32 - 1. If you want static mTLS from files, load the bytes yourself with the file-loading helper and use the byte-based mode.
+* **Sub-second, zero, negative, and oversized reload intervals are rejected.** The custom interval is validated at configuration time: it must be a positive whole number of seconds no greater than 4,294,967,295 (the maximum value of an unsigned 32-bit integer, roughly 136 years). If you want static mTLS from files, load the bytes yourself with the file-loading helper and use the byte-based mode.
 * **Byte-based mTLS is static.** The material is read once at connect time and never reloads. Use a path-based mode when the certificate rotates.
 * **Reload cadence is a lower bound.** The interval bounds how stale the on-disk material can be before the next reload attempt; the next successful reload takes effect on the next reconnect, not on open connections.
 * **Reload failures keep the last known-good material.** A path that becomes unreadable, a mismatched key, or a corrupt certificate causes the reload to fail. The core keeps the last successfully loaded material and retries at the next tick.

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -637,21 +637,143 @@ You can provide custom root certificates for TLS connections. This is useful whe
   </TabItem>
 
   <TabItem label="Java">
-    :::note[Coming soon]
-    Custom root certificate documentation for Java is coming soon.
-    :::
+    **Certificate Behavior:**
+
+    * If `rootCertificates` is not set (default), the system's default certificate trust store is used
+    * If `rootCertificates` is an empty byte array, an error will be returned
+    * Certificates must be in PEM format as a byte array
+    * Multiple certificates can be provided by concatenating them in PEM format
+
+    #### Example - Connecting with Custom Root Certificate from File
+
+    ```java
+    import glide.api.GlideClusterClient;
+    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+    import glide.api.models.configuration.GlideClusterClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.TlsAdvancedConfiguration;
+
+    import java.nio.file.Files;
+    import java.nio.file.Paths;
+
+    byte[] rootCaBytes = Files.readAllBytes(Paths.get("/path/to/ca-cert.pem"));
+
+    TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
+        .rootCertificates(rootCaBytes)
+        .build();
+
+    AdvancedGlideClusterClientConfiguration advancedConfig =
+        AdvancedGlideClusterClientConfiguration.builder()
+            .tlsAdvancedConfiguration(tlsConfig)
+            .build();
+
+    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
+        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
+        .useTLS(true)
+        .advancedConfiguration(advancedConfig)
+        .build();
+
+    GlideClusterClient client = GlideClusterClient.createClient(config).get();
+    ```
+
+    #### Example - Connecting with Custom Root Certificates from KeyStore
+
+    `TlsAdvancedConfiguration.fromKeyStore` is a static factory that pulls trusted certificate entries out of a Java `KeyStore` (JKS or PKCS12) and returns a fully-configured `TlsAdvancedConfiguration`.
+
+    ```java
+    import glide.api.GlideClusterClient;
+    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+    import glide.api.models.configuration.GlideClusterClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.TlsAdvancedConfiguration;
+
+    TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.fromKeyStore(
+        "/path/to/truststore.p12",
+        "changeit".toCharArray(),
+        "PKCS12");
+
+    AdvancedGlideClusterClientConfiguration advancedConfig =
+        AdvancedGlideClusterClientConfiguration.builder()
+            .tlsAdvancedConfiguration(tlsConfig)
+            .build();
+
+    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
+        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
+        .useTLS(true)
+        .advancedConfiguration(advancedConfig)
+        .build();
+
+    GlideClusterClient client = GlideClusterClient.createClient(config).get();
+    ```
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Custom root certificate documentation for Node.js is coming soon.
-    :::
+    **Certificate Behavior:**
+
+    * If `rootCertificates` is not set (default), the system's default certificate trust store is used
+    * If `rootCertificates` is empty, an error will be returned
+    * Certificates must be in PEM format, provided as a `Buffer` or a raw PEM `string`
+    * Multiple certificates can be provided by concatenating them in PEM format
+
+    #### Example - Connecting with Custom Root Certificate from File
+
+    ```typescript
+    import { readFileSync } from "node:fs";
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    const rootCertificates = readFileSync("/path/to/ca-cert.pem");
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { rootCertificates },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
-    :::note[Coming soon]
-    Custom root certificate documentation for Go is coming soon.
-    :::
+    **Certificate Behavior:**
+
+    * If `WithRootCertificates` is not called (default), the system's default certificate trust store is used
+    * Certificates must be in PEM format as a byte slice
+    * Multiple certificates can be provided by concatenating them in PEM format
+    * `config.LoadRootCertificatesFromFile` reads a PEM file and returns the bytes, ready to pass to `WithRootCertificates`
+
+    #### Example - Connecting with Custom Root Certificate from File
+
+    ```go
+    import (
+        glide "github.com/valkey-io/valkey-glide/go/v2"
+        "github.com/valkey-io/valkey-glide/go/v2/config"
+    )
+
+    func ConnectClusterWithCustomRootCA() error {
+        rootCerts, err := config.LoadRootCertificatesFromFile("/path/to/ca-cert.pem")
+        if err != nil {
+            return err
+        }
+
+        tlsConfig := config.NewTlsConfiguration().WithRootCertificates(rootCerts)
+
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
+
+        clientConfig := config.NewClusterClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
+            WithUseTLS(true).
+            WithAdvancedConfiguration(advancedConfig)
+
+        client, err := glide.NewClusterClient(clientConfig)
+        if err != nil {
+            return err
+        }
+        defer client.Close()
+
+        return nil
+    }
+    ```
   </TabItem>
 
   <TabItem label="C#">

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -1369,7 +1369,7 @@ The same file-loading helpers work for both `GlideClient` (standalone) and `Glid
         NodeAddress,
         TlsAdvancedConfiguration,
     )
-    from glide_shared.config import load_client_certificate_and_key_from_file
+    from glide import load_client_certificate_and_key_from_file
 
     cert, key = load_client_certificate_and_key_from_file(
         "/etc/glide/client.pem",

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -618,18 +618,56 @@ Prefer path-based mTLS with a key file whose read permissions are restricted to 
 In-memory PEM bytes must come from a secret store, not from source.
 :::
 
-mTLS still requires `use_tls=True` on the top-level configuration.
-The advanced TLS configuration only supplies the client-side material.
+mTLS still requires TLS to be enabled on the top-level client configuration (`use_tls=True` in Python, `.useTLS(true)` in Java, `useTLS: true` in Node.js, `.WithUseTLS(true)` in Go).
+The advanced TLS configuration only supplies the client-side material; it does not enable TLS on its own.
+
+Reload behavior applies to path-based modes only.
+The GLIDE core reads the certificate and key from disk at connect time and re-reads them on a schedule so a rotated certificate is picked up on the next reconnect.
+Open connections keep their current material.
+If a reload fails (missing file, mismatched key, unreadable), the last known-good material is kept until a subsequent read succeeds.
+Byte-based mTLS is inherently static: the material is read once at connect time and does not reload.
+
+Path-based and byte-based mTLS are mutually exclusive within a single configuration.
+Supplying both is rejected at configuration time in every SDK.
+
+A custom reload interval must be a positive whole number of seconds no greater than 2^32 - 1.
+Sub-second, zero, negative, and oversized values are rejected at configuration time.
 
 #### In-memory PEM (static)
 
-Use `WithMutualTLS(cert, key)` (Go) or `useMutualTls(byte[], byte[])` (Java) when the client certificate and key are already loaded as PEM bytes.
+Use the byte-based entry point when the client certificate and key are already loaded as PEM bytes (for example, fetched from a secret store).
+The material is read once at connect time and does not reload.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Python is coming soon.
-    :::
+    ```python
+    from glide import (
+        AdvancedGlideClusterClientConfiguration,
+        GlideClusterClient,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        TlsAdvancedConfiguration,
+    )
+
+    # Load PEM bytes from a secret store, not from source.
+    client_cert: bytes = ...
+    client_key: bytes = ...
+
+    tls_config = TlsAdvancedConfiguration(
+        client_cert_pem=client_cert,
+        client_key_pem=client_key,
+    )
+
+    advanced_config = AdvancedGlideClusterClientConfiguration(tls_config=tls_config)
+
+    client_config = GlideClusterClientConfiguration(
+        addresses=[NodeAddress(host="address.example.com", port=6379)],
+        use_tls=True,
+        advanced_config=advanced_config,
+    )
+
+    client = await GlideClusterClient.create(client_config)
+    ```
   </TabItem>
 
   <TabItem label="Java">
@@ -663,9 +701,27 @@ Use `WithMutualTLS(cert, key)` (Go) or `useMutualTls(byte[], byte[])` (Java) whe
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient, MutualTls } from "@valkey/valkey-glide";
+
+    // Load PEM bytes from a secret store, not from source.
+    const clientCertificate: Buffer = /* PEM-encoded certificate bytes */;
+    const clientKey: Buffer = /* PEM-encoded private key bytes */;
+
+    const mutualTls: MutualTls = {
+        kind: "bytes",
+        clientCertificate,
+        clientKey,
+    };
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { mutualTls },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -673,39 +729,29 @@ Use `WithMutualTLS(cert, key)` (Go) or `useMutualTls(byte[], byte[])` (Java) whe
     import (
         glide "github.com/valkey-io/valkey-glide/go/v2"
         "github.com/valkey-io/valkey-glide/go/v2/config"
-        "log"
     )
 
     func ConnectClusterWithMutualTLSBytes() error {
-        // Load certificate and key bytes from a secret store (not from source).
-        clientCert := []byte(`-----BEGIN CERTIFICATE-----
-MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKmzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-...
------END CERTIFICATE-----`)
-        clientKey := []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7...
------END PRIVATE KEY-----`)
+        // Load PEM bytes from a secret store, not from source.
+        var clientCert []byte = /* PEM-encoded certificate bytes */
+        var clientKey []byte  = /* PEM-encoded private key bytes */
 
-        // Create TLS configuration with in-memory client cert and key.
-        // The cert and key are loaded once at connection time (static, no reload).
         tlsConfig, err := config.NewTlsConfiguration().WithMutualTLS(clientCert, clientKey)
         if err != nil {
-            log.Fatalf("Failed to create TLS config: %v", err)
+            return err
         }
 
-        // Set up advanced configuration with TLS.
-        advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
 
-        // Create cluster client configuration.
-        myConfig := config.NewClusterClientConfiguration().
+        clientConfig := config.NewClusterClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
             WithUseTLS(true).
             WithAdvancedConfiguration(advancedConfig)
 
-        // Create the client.
-        client, err := glide.NewClusterClient(myConfig)
+        client, err := glide.NewClusterClient(clientConfig)
         if err != nil {
-            log.Fatalf("Failed to create cluster client: %v", err)
+            return err
         }
         defer client.Close()
 
@@ -716,26 +762,48 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7...
 
   <TabItem label="C#">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
+    Mutual TLS is not yet available in the C# client.
     :::
   </TabItem>
 
   <TabItem label="PHP">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for PHP is coming soon.
+    Mutual TLS is not yet available in the PHP client.
     :::
   </TabItem>
 </Tabs>
 
 #### Path-based with automatic reload
 
-Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(certPath, keyPath)` (Java) to point at files on disk; the core re-reads the material at its default cadence (currently 300 seconds).
+Point at PEM files on disk and let the core reload them at its default cadence.
+Rotated material is picked up on the next reconnect after a successful reload.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Python is coming soon.
-    :::
+    ```python
+    from glide import (
+        AdvancedGlideClusterClientConfiguration,
+        GlideClusterClient,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        TlsAdvancedConfiguration,
+    )
+
+    tls_config = TlsAdvancedConfiguration(
+        client_cert_path="/etc/glide/client.pem",
+        client_key_path="/etc/glide/client.key",
+    )
+
+    advanced_config = AdvancedGlideClusterClientConfiguration(tls_config=tls_config)
+
+    client_config = GlideClusterClientConfiguration(
+        addresses=[NodeAddress(host="address.example.com", port=6379)],
+        use_tls=True,
+        advanced_config=advanced_config,
+    )
+
+    client = await GlideClusterClient.create(client_config)
+    ```
   </TabItem>
 
   <TabItem label="Java">
@@ -747,7 +815,7 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
     import glide.api.models.configuration.TlsAdvancedConfiguration;
 
     TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
-        .useMutualTlsWithReload("/path/to/client-cert.pem", "/path/to/client-key.pem")
+        .useMutualTlsWithReload("/etc/glide/client.pem", "/etc/glide/client.key")
         .build();
 
     AdvancedGlideClusterClientConfiguration advancedConfig =
@@ -766,9 +834,23 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient, MutualTls } from "@valkey/valkey-glide";
+
+    const mutualTls: MutualTls = {
+        kind: "path",
+        clientCertPath: "/etc/glide/client.pem",
+        clientKeyPath: "/etc/glide/client.key",
+    };
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { mutualTls },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -776,33 +858,28 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
     import (
         glide "github.com/valkey-io/valkey-glide/go/v2"
         "github.com/valkey-io/valkey-glide/go/v2/config"
-        "log"
     )
 
-    func ConnectStandaloneWithMutualTLSFilesDefaultReload() error {
-        // Create TLS configuration with client cert/key file paths.
-        // The core will re-read the files at the default cadence (currently 300 seconds).
+    func ConnectClusterWithMutualTLSFromFiles() error {
         tlsConfig, err := config.NewTlsConfiguration().WithMutualTLSFromFiles(
-            "/path/to/client-cert.pem",
-            "/path/to/client-key.pem",
+            "/etc/glide/client.pem",
+            "/etc/glide/client.key",
         )
         if err != nil {
-            log.Fatalf("Failed to create TLS config: %v", err)
+            return err
         }
 
-        // Set up advanced configuration with TLS.
-        advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
 
-        // Create standalone client configuration.
-        myConfig := config.NewClientConfiguration().
-            WithAddress(&config.NodeAddress{Host: "primary.example.com", Port: 6379}).
+        clientConfig := config.NewClusterClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
             WithUseTLS(true).
             WithAdvancedConfiguration(advancedConfig)
 
-        // Create the client.
-        client, err := glide.NewClient(myConfig)
+        client, err := glide.NewClusterClient(clientConfig)
         if err != nil {
-            log.Fatalf("Failed to create client: %v", err)
+            return err
         }
         defer client.Close()
 
@@ -813,26 +890,48 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
 
   <TabItem label="C#">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
+    Mutual TLS is not yet available in the C# client.
     :::
   </TabItem>
 
   <TabItem label="PHP">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for PHP is coming soon.
+    Mutual TLS is not yet available in the PHP client.
     :::
   </TabItem>
 </Tabs>
 
 #### Path-based with a custom reload interval
 
-Pass a positive interval in seconds to override the core default. In Java, use `useMutualTlsWithReload(certPath, keyPath, intervalSecs)`. In Go, pass `config.WithReloadInterval(d)` to `WithMutualTLSFromFiles()`.
+Pass a positive whole number of seconds to override the core default cadence.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Python is coming soon.
-    :::
+    ```python
+    from glide import (
+        AdvancedGlideClusterClientConfiguration,
+        GlideClusterClient,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        TlsAdvancedConfiguration,
+    )
+
+    tls_config = TlsAdvancedConfiguration(
+        client_cert_path="/etc/glide/client.pem",
+        client_key_path="/etc/glide/client.key",
+        cert_reload_interval_seconds=60,
+    )
+
+    advanced_config = AdvancedGlideClusterClientConfiguration(tls_config=tls_config)
+
+    client_config = GlideClusterClientConfiguration(
+        addresses=[NodeAddress(host="address.example.com", port=6379)],
+        use_tls=True,
+        advanced_config=advanced_config,
+    )
+
+    client = await GlideClusterClient.create(client_config)
+    ```
   </TabItem>
 
   <TabItem label="Java">
@@ -844,7 +943,7 @@ Pass a positive interval in seconds to override the core default. In Java, use `
     import glide.api.models.configuration.TlsAdvancedConfiguration;
 
     TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
-        .useMutualTlsWithReload("/path/to/client-cert.pem", "/path/to/client-key.pem", 60)
+        .useMutualTlsWithReload("/etc/glide/client.pem", "/etc/glide/client.key", 60)
         .build();
 
     AdvancedGlideClusterClientConfiguration advancedConfig =
@@ -863,9 +962,24 @@ Pass a positive interval in seconds to override the core default. In Java, use `
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient, MutualTls } from "@valkey/valkey-glide";
+
+    const mutualTls: MutualTls = {
+        kind: "path",
+        clientCertPath: "/etc/glide/client.pem",
+        clientKeyPath: "/etc/glide/client.key",
+        reloadIntervalSeconds: 60,
+    };
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { mutualTls },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -873,35 +987,29 @@ Pass a positive interval in seconds to override the core default. In Java, use `
     import (
         glide "github.com/valkey-io/valkey-glide/go/v2"
         "github.com/valkey-io/valkey-glide/go/v2/config"
-        "log"
-        "time"
     )
 
-    func ConnectClusterWithMutualTLSFilesCustomReload() error {
-        // Create TLS configuration with client cert/key file paths and custom reload interval.
-        // The core will re-read the files every 60 seconds.
+    func ConnectClusterWithMutualTLSCustomInterval() error {
         tlsConfig, err := config.NewTlsConfiguration().WithMutualTLSFromFiles(
-            "/path/to/client-cert.pem",
-            "/path/to/client-key.pem",
-            config.WithReloadInterval(60*time.Second),
+            "/etc/glide/client.pem",
+            "/etc/glide/client.key",
+            config.WithReloadInterval(60),
         )
         if err != nil {
-            log.Fatalf("Failed to create TLS config: %v", err)
+            return err
         }
 
-        // Set up advanced configuration with TLS.
-        advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
 
-        // Create cluster client configuration.
-        myConfig := config.NewClusterClientConfiguration().
+        clientConfig := config.NewClusterClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
             WithUseTLS(true).
             WithAdvancedConfiguration(advancedConfig)
 
-        // Create the client.
-        client, err := glide.NewClusterClient(myConfig)
+        client, err := glide.NewClusterClient(clientConfig)
         if err != nil {
-            log.Fatalf("Failed to create cluster client: %v", err)
+            return err
         }
         defer client.Close()
 
@@ -912,26 +1020,51 @@ Pass a positive interval in seconds to override the core default. In Java, use `
 
   <TabItem label="C#">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
+    Mutual TLS is not yet available in the C# client.
     :::
   </TabItem>
 
   <TabItem label="PHP">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for PHP is coming soon.
+    Mutual TLS is not yet available in the PHP client.
     :::
   </TabItem>
 </Tabs>
 
 #### Loading PEM material from files
 
-Helpers exist to read PEM bytes from disk and feed the in-memory mode.
+When static, byte-based mTLS is desired but the material lives on disk, each SDK offers a helper that reads the PEM files and returns the bytes.
+Feed those bytes into the byte-based entry point shown above.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Python is coming soon.
-    :::
+    ```python
+    from glide import (
+        AdvancedGlideClientConfiguration,
+        GlideClient,
+        GlideClientConfiguration,
+        NodeAddress,
+        TlsAdvancedConfiguration,
+    )
+    from glide_shared.config import load_client_certificate_and_key_from_file
+
+    cert, key = load_client_certificate_and_key_from_file(
+        "/etc/glide/client.pem",
+        "/etc/glide/client.key",
+    )
+
+    tls_config = TlsAdvancedConfiguration(client_cert_pem=cert, client_key_pem=key)
+
+    advanced_config = AdvancedGlideClientConfiguration(tls_config=tls_config)
+
+    client_config = GlideClientConfiguration(
+        addresses=[NodeAddress(host="primary.example.com", port=6379)],
+        use_tls=True,
+        advanced_config=advanced_config,
+    )
+
+    client = await GlideClient.create(client_config)
+    ```
   </TabItem>
 
   <TabItem label="Java">
@@ -943,8 +1076,8 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
     import glide.api.models.configuration.TlsAdvancedConfiguration;
     import glide.api.models.configuration.TlsAdvancedConfiguration.TlsAdvancedConfigurationBuilder;
 
-    byte[] cert = TlsAdvancedConfigurationBuilder.loadClientCertificateFromFile("/path/to/client-cert.pem");
-    byte[] key  = TlsAdvancedConfigurationBuilder.loadClientKeyFromFile("/path/to/client-key.pem");
+    byte[] cert = TlsAdvancedConfigurationBuilder.loadClientCertificateFromFile("/etc/glide/client.pem");
+    byte[] key  = TlsAdvancedConfigurationBuilder.loadClientKeyFromFile("/etc/glide/client.key");
 
     TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
         .useMutualTls(cert, key)
@@ -965,9 +1098,32 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import {
+        GlideClient,
+        MutualTls,
+        loadClientCertificateAndKeyFromFile,
+    } from "@valkey/valkey-glide";
+
+    const { cert, key } = await loadClientCertificateAndKeyFromFile(
+        "/etc/glide/client.pem",
+        "/etc/glide/client.key",
+    );
+
+    const mutualTls: MutualTls = {
+        kind: "bytes",
+        clientCertificate: cert,
+        clientKey: key,
+    };
+
+    const client = await GlideClient.createClient({
+        addresses: [{ host: "primary.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: { mutualTls },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -975,38 +1131,33 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
     import (
         glide "github.com/valkey-io/valkey-glide/go/v2"
         "github.com/valkey-io/valkey-glide/go/v2/config"
-        "log"
     )
 
     func ConnectStandaloneWithMutualTLSFromFileLoader() error {
-        // Use the helper to load both cert and key from files.
         cert, key, err := config.LoadClientCertificateAndKeyFromFile(
-            "/path/to/client-cert.pem",
-            "/path/to/client-key.pem",
+            "/etc/glide/client.pem",
+            "/etc/glide/client.key",
         )
         if err != nil {
-            log.Fatalf("Failed to load certificates: %v", err)
+            return err
         }
 
-        // Create TLS configuration with the loaded in-memory bytes (static, no reload).
         tlsConfig, err := config.NewTlsConfiguration().WithMutualTLS(cert, key)
         if err != nil {
-            log.Fatalf("Failed to create TLS config: %v", err)
+            return err
         }
 
-        // Set up advanced configuration with TLS.
-        advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+        advancedConfig := config.NewAdvancedClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
 
-        // Create standalone client configuration.
-        myConfig := config.NewClientConfiguration().
+        clientConfig := config.NewClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "primary.example.com", Port: 6379}).
             WithUseTLS(true).
             WithAdvancedConfiguration(advancedConfig)
 
-        // Create the client.
-        client, err := glide.NewClient(myConfig)
+        client, err := glide.NewClient(clientConfig)
         if err != nil {
-            log.Fatalf("Failed to create client: %v", err)
+            return err
         }
         defer client.Close()
 
@@ -1017,29 +1168,26 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
 
   <TabItem label="C#">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
+    Mutual TLS is not yet available in the C# client.
     :::
   </TabItem>
 
   <TabItem label="PHP">
     :::note[Coming soon]
-    Mutual TLS configuration documentation for PHP is coming soon.
+    Mutual TLS is not yet available in the PHP client.
     :::
   </TabItem>
 </Tabs>
 
 #### Common Pitfalls
 
-* **File permissions:** the process user must have read access on the cert and key files.
-  A path that becomes unreadable mid-run causes the reload to fail; the last known-good material is kept until a subsequent read succeeds.
-* **Reload cadence:** the interval is a lower bound on how fresh the material will be at the next reconnect.
-  Newly picked-up material takes effect at the next connection attempt, not immediately.
-* **Path vs bytes are exclusive:** do not mix modes on the same builder.
-  In Go, calling both `WithMutualTLS` and `WithMutualTLSFromFiles` on the same `TlsConfiguration` will replace the previous setting (the last call wins).
-  To switch modes, create a new `TlsConfiguration`.
-* **Sub-second and non-positive intervals are rejected:** in Go these fail with an error at configuration time.
-  If you want static mTLS from files, load the bytes yourself using `LoadClientCertificateAndKeyFromFile` and use `WithMutualTLS(cert, key)`.
-* **mTLS still needs `use_tls=True`:** the advanced TLS configuration only fills in the client-side material and does not enable TLS by itself.
+* **mTLS still needs TLS enabled at the top level.** The advanced TLS configuration only supplies the client-side material; without TLS on the base client configuration (`use_tls=True`, `.useTLS(true)`, `useTLS: true`, or `.WithUseTLS(true)`), the client connects in plaintext and the mTLS material is not used.
+* **Path-based and byte-based mTLS are mutually exclusive.** Supplying both a certificate/key path and inline PEM bytes on the same configuration is a configuration error in every SDK.
+* **Sub-second, zero, negative, and oversized reload intervals are rejected.** The custom interval is validated at configuration time: it must be a positive whole number of seconds no greater than 2^32 - 1. If you want static mTLS from files, load the bytes yourself with the file-loading helper and use the byte-based mode.
+* **Byte-based mTLS is static.** The material is read once at connect time and never reloads. Use a path-based mode when the certificate rotates.
+* **Reload cadence is a lower bound.** The interval bounds how stale the on-disk material can be before the next reload attempt; the next successful reload takes effect on the next reconnect, not on open connections.
+* **Reload failures keep the last known-good material.** A path that becomes unreadable, a mismatched key, or a corrupt certificate causes the reload to fail. The core keeps the last successfully loaded material and retries at the next tick.
+* **File permissions matter.** The process user must have read access to the certificate and key files. Restrict the key file to that user; do not commit it or log it.
 
 ### TLS Certificate Format
 

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -74,12 +74,18 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
         "github.com/valkey-io/valkey-glide/go/v2/config"
     )
 
-    func ConnectClusterWithTLS() {
-        myConfig := config.NewClusterClientConfiguration().
+    func ConnectClusterWithTLS() error {
+        clientConfig := config.NewClusterClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
             WithUseTLS(true)
 
-        client, err := glide.NewClusterClient(myConfig)
+        client, err := glide.NewClusterClient(clientConfig)
+        if err != nil {
+            return err
+        }
+        defer client.Close()
+
+        return nil
     }
     ```
   </TabItem>
@@ -187,12 +193,18 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
         "github.com/valkey-io/valkey-glide/go/v2/config"
     )
 
-    func ConnectStandaloneWithTLS() {
-        myConfig := config.NewClientConfiguration().
+    func ConnectStandaloneWithTLS() error {
+        clientConfig := config.NewClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "primary.example.com", Port: 6379}).
             WithUseTLS(true)
 
-        client, err := glide.NewClient(myConfig)
+        client, err := glide.NewClient(clientConfig)
+        if err != nil {
+            return err
+        }
+        defer client.Close()
+
+        return nil
     }
     ```
   </TabItem>

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -251,28 +251,27 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
 **SECURITY WARNING**: Insecure mode is only for development and testing environments. **It is strongly discouraged in production environments** as it introduces security risks such as man-in-the-middle attacks.
 :::
 
+#### Cluster Mode
+
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
     ```python
     from glide import (
+        AdvancedGlideClusterClientConfiguration,
         GlideClusterClient,
         GlideClusterClientConfiguration,
         NodeAddress,
         TlsAdvancedConfiguration,
-        AdvancedGlideClusterClientConfiguration
     )
 
     tls_config = TlsAdvancedConfiguration(use_insecure_tls=True)
 
-    advanced_config = AdvancedGlideClusterClientConfiguration(
-        tls_config=tls_config
-    )
+    advanced_config = AdvancedGlideClusterClientConfiguration(tls_config=tls_config)
 
-    addresses = [NodeAddress(host="address.example.com", port=6379)]
     client_config = GlideClusterClientConfiguration(
-        addresses,
+        addresses=[NodeAddress(host="address.example.com", port=6379)],
         use_tls=True,
-        advanced_config=advanced_config
+        advanced_config=advanced_config,
     )
 
     client = await GlideClusterClient.create(client_config)
@@ -280,9 +279,30 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
   </TabItem>
 
   <TabItem label="Java">
-    :::note[Coming soon]
-    Insecure TLS configuration documentation for Java is coming soon.
-    :::
+    ```java
+    import glide.api.GlideClusterClient;
+    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+    import glide.api.models.configuration.GlideClusterClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.TlsAdvancedConfiguration;
+
+    TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
+        .useInsecureTLS(true)
+        .build();
+
+    AdvancedGlideClusterClientConfiguration advancedConfig =
+        AdvancedGlideClusterClientConfiguration.builder()
+            .tlsAdvancedConfiguration(tlsConfig)
+            .build();
+
+    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
+        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
+        .useTLS(true)
+        .advancedConfiguration(advancedConfig)
+        .build();
+
+    GlideClusterClient client = GlideClusterClient.createClient(config).get();
+    ```
   </TabItem>
 
   <TabItem label="Node">
@@ -320,6 +340,110 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
         advanced_config: ['tls_config' => ['use_insecure_tls' => true]]
     );
     ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    :::note[Not currently supported]
+    The Ruby client (`valkey-glide-rb`) does not currently expose a way to skip TLS certificate verification. Its TLS options accept a CA bundle and client key material through `ssl_params`, but there is no `insecure`, `verify_mode`, or equivalent flag. For local testing with a self-signed certificate, pass the CA bundle via `ssl_params: { ca_file: "/path/to/ca-cert.pem" }` instead.
+    :::
+  </TabItem>
+</Tabs>
+
+#### Standalone
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    from glide import (
+        AdvancedGlideClientConfiguration,
+        GlideClient,
+        GlideClientConfiguration,
+        NodeAddress,
+        TlsAdvancedConfiguration,
+    )
+
+    tls_config = TlsAdvancedConfiguration(use_insecure_tls=True)
+
+    advanced_config = AdvancedGlideClientConfiguration(tls_config=tls_config)
+
+    client_config = GlideClientConfiguration(
+        addresses=[NodeAddress(host="primary.example.com", port=6379)],
+        use_tls=True,
+        advanced_config=advanced_config,
+    )
+
+    client = await GlideClient.create(client_config)
+    ```
+  </TabItem>
+
+  <TabItem label="Java">
+    ```java
+    import glide.api.GlideClient;
+    import glide.api.models.configuration.AdvancedGlideClientConfiguration;
+    import glide.api.models.configuration.GlideClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.TlsAdvancedConfiguration;
+
+    TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
+        .useInsecureTLS(true)
+        .build();
+
+    AdvancedGlideClientConfiguration advancedConfig = AdvancedGlideClientConfiguration.builder()
+        .tlsAdvancedConfiguration(tlsConfig)
+        .build();
+
+    GlideClientConfiguration config = GlideClientConfiguration.builder()
+        .address(NodeAddress.builder().host("primary.example.com").port(6379).build())
+        .useTLS(true)
+        .advancedConfiguration(advancedConfig)
+        .build();
+
+    GlideClient client = GlideClient.createClient(config).get();
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    :::note[Coming soon]
+    Insecure TLS configuration documentation for Node.js is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="Go">
+    :::note[Coming soon]
+    Insecure TLS configuration documentation for Go is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new StandaloneClientConfigurationBuilder()
+        .WithAddress("primary.example.com", 6379)
+        .WithTls()
+        .WithInsecureTls()
+        .Build();
+
+    await using var client = await GlideClient.CreateClient(config);
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    ```php
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'primary.example.com', 'port' => 6379]],
+        use_tls: true,
+        advanced_config: ['tls_config' => ['use_insecure_tls' => true]]
+    );
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    :::note[Not currently supported]
+    The Ruby client (`valkey-glide-rb`) does not currently expose a way to skip TLS certificate verification. Its TLS options accept a CA bundle and client key material through `ssl_params`, but there is no `insecure`, `verify_mode`, or equivalent flag. For local testing with a self-signed certificate, pass the CA bundle via `ssl_params: { ca_file: "/path/to/ca-cert.pem" }` instead.
+    :::
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -998,8 +998,9 @@ The material is read once at connect time and does not reload.
     import glide.api.models.configuration.NodeAddress;
     import glide.api.models.configuration.TlsAdvancedConfiguration;
 
-    byte[] clientCert = /* PEM-encoded certificate bytes from a secret store */;
-    byte[] clientKey  = /* PEM-encoded private key bytes from a secret store */;
+    // Replace loadPemFromSecretStore(...) with your own secret-store lookup returning PEM-encoded bytes.
+    byte[] clientCert = loadPemFromSecretStore("client-cert");
+    byte[] clientKey  = loadPemFromSecretStore("client-key");
 
     TlsAdvancedConfiguration tlsConfig = TlsAdvancedConfiguration.builder()
         .useMutualTls(clientCert, clientKey)
@@ -1025,8 +1026,9 @@ The material is read once at connect time and does not reload.
     import { GlideClusterClient, MutualTls } from "@valkey/valkey-glide";
 
     // Load PEM bytes from a secret store, not from source.
-    const clientCertificate: Buffer = /* PEM-encoded certificate bytes */;
-    const clientKey: Buffer = /* PEM-encoded private key bytes */;
+    // Replace loadPemFromSecretStore(...) with your own secret-store lookup returning PEM-encoded bytes.
+    const clientCertificate: Buffer = loadPemFromSecretStore("client-cert");
+    const clientKey: Buffer = loadPemFromSecretStore("client-key");
 
     const mutualTls: MutualTls = {
         kind: "bytes",
@@ -1052,9 +1054,8 @@ The material is read once at connect time and does not reload.
     )
 
     func ConnectClusterWithMutualTLSBytes() error {
-        // Load PEM bytes from a secret store, not from source.
-        var clientCert []byte = /* PEM-encoded certificate bytes */
-        var clientKey []byte  = /* PEM-encoded private key bytes */
+        // Replace loadPemFromSecretStore(...) with your own secret-store lookup returning PEM-encoded bytes.
+        clientCert, clientKey := loadPemFromSecretStore()
 
         tlsConfig, err := config.NewTlsConfiguration().WithMutualTLS(clientCert, clientKey)
         if err != nil {
@@ -1355,6 +1356,8 @@ Pass a positive whole number of seconds to override the core default cadence.
 
 When static, byte-based mTLS is desired but the material lives on disk, each SDK offers a helper that reads the PEM files and returns the bytes.
 Feed those bytes into the byte-based entry point shown above.
+
+The same file-loading helpers work for both `GlideClient` (standalone) and `GlideClusterClient` (cluster-mode). The examples below show the standalone client; substitute the cluster variant if you are connecting to a cluster.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -320,9 +320,32 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
   </TabItem>
 
   <TabItem label="Go">
-    :::note[Coming soon]
-    Insecure TLS configuration documentation for Go is coming soon.
-    :::
+    ```go
+    import (
+        glide "github.com/valkey-io/valkey-glide/go/v2"
+        "github.com/valkey-io/valkey-glide/go/v2/config"
+    )
+
+    func ConnectClusterWithInsecureTLS() error {
+        tlsConfig := config.NewTlsConfiguration().WithInsecureTLS(true)
+
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
+
+        clientConfig := config.NewClusterClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
+            WithUseTLS(true).
+            WithAdvancedConfiguration(advancedConfig)
+
+        client, err := glide.NewClusterClient(clientConfig)
+        if err != nil {
+            return err
+        }
+        defer client.Close()
+
+        return nil
+    }
+    ```
   </TabItem>
 
   <TabItem label="C#">
@@ -425,9 +448,32 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
   </TabItem>
 
   <TabItem label="Go">
-    :::note[Coming soon]
-    Insecure TLS configuration documentation for Go is coming soon.
-    :::
+    ```go
+    import (
+        glide "github.com/valkey-io/valkey-glide/go/v2"
+        "github.com/valkey-io/valkey-glide/go/v2/config"
+    )
+
+    func ConnectStandaloneWithInsecureTLS() error {
+        tlsConfig := config.NewTlsConfiguration().WithInsecureTLS(true)
+
+        advancedConfig := config.NewAdvancedClientConfiguration().
+            WithTlsConfiguration(tlsConfig)
+
+        clientConfig := config.NewClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "primary.example.com", Port: 6379}).
+            WithUseTLS(true).
+            WithAdvancedConfiguration(advancedConfig)
+
+        client, err := glide.NewClient(clientConfig)
+        if err != nil {
+            return err
+        }
+        defer client.Close()
+
+        return nil
+    }
+    ```
   </TabItem>
 
   <TabItem label="C#">


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE Documentation!
-->

### Summary

Updates `src/content/docs/how-to/security/tls.mdx` so Python, Java, Node.js, and Go each have real, source-verified samples for basic TLS, Insecure TLS, Custom Root Certificates, and Mutual TLS (mTLS). Every added sample matches the current source on `main` in `valkey-io/valkey-glide`.

### Issue link

Documents TLS functionality shipped in the client SDKs. Source PRs:

- Java + glide-core: [valkey-io/valkey-glide#6386](https://github.com/valkey-io/valkey-glide/pull/6386)
- Python (initial): [valkey-io/valkey-glide#5124](https://github.com/valkey-io/valkey-glide/pull/5124)
- Python (automatic reload): [valkey-io/valkey-glide#6596](https://github.com/valkey-io/valkey-glide/pull/6596)
- Node.js: [valkey-io/valkey-glide#6383](https://github.com/valkey-io/valkey-glide/pull/6383)
- Go: [valkey-io/valkey-glide#6384](https://github.com/valkey-io/valkey-glide/pull/6384)
- Field-name alignment and reload-interval bounding: [valkey-io/valkey-glide#6678](https://github.com/valkey-io/valkey-glide/pull/6678)

### Content Changes

`src/content/docs/how-to/security/tls.mdx`:

- **Insecure TLS Mode**: split into `#### Cluster Mode` and `#### Standalone` subsections, each with Python, Java, Node.js, and Go tabs.
- **Custom Root Certificates**: Java, Node.js, and Go now have real code. Java shows both `TlsAdvancedConfiguration.builder().rootCertificates(byte[])` from a PEM file and the `TlsAdvancedConfiguration.fromKeyStore(path, password, type)` factory for JKS or PKCS12 trust stores. Node.js uses `readFileSync` with `advancedConfiguration.tlsAdvancedConfiguration.rootCertificates`. Go uses `config.LoadRootCertificatesFromFile` with `config.NewTlsConfiguration().WithRootCertificates(...)`.
- **Mutual TLS (mTLS)**: real code for Python, Java, Node.js, and Go across the three shipped modes (in-memory PEM, path-based with automatic reload, path-based with a custom reload interval), plus a "Loading PEM material from files" subsection showing each SDK's file-loading helper.
- **Bug fixes**: Python samples had a phantom `advanced_configuration=` kwarg; correct kwarg per `python/glide-shared/glide_shared/config.py` is `advanced_config=`. Go TLS samples had unused `client, err` bindings that failed `go build`; samples now return an `error` and `defer client.Close()`.

### Implementation

- **Python**: `glide_shared.config.TlsAdvancedConfiguration` with `use_insecure_tls`, `root_pem_cacerts`, `client_cert_pem` / `client_key_pem` / `client_cert_path` / `client_key_path` / `cert_reload_interval_seconds`; plumbed via `AdvancedGlideClusterClientConfiguration(tls_config=...)` and `AdvancedGlideClientConfiguration(tls_config=...)`.
- **Java**: `TlsAdvancedConfiguration.builder().useInsecureTLS(true).build()` for Insecure TLS; `.rootCertificates(byte[])` and `TlsAdvancedConfiguration.fromKeyStore(...)` for Custom Root Certificates; `useMutualTls(byte[], byte[])`, `useMutualTlsWithReload(String, String)`, and `useMutualTlsWithReload(String, String, int)` for mTLS. Plumbed via `AdvancedGlideClusterClientConfiguration` and `AdvancedGlideClientConfiguration`.
- **Node.js**: `advancedConfiguration.tlsAdvancedConfiguration.insecure: true` for Insecure TLS; `rootCertificates: Buffer | string` for Custom Root Certificates; the `MutualTls` discriminated union (`kind: "bytes"` and `kind: "path"` with optional `reloadIntervalSeconds`) for mTLS. Note: the field name on the Node.js TypeScript surface is `insecure`, not `useInsecureTLS`.
- **Go**: `config.NewTlsConfiguration().WithInsecureTLS(true)` for Insecure TLS; `config.LoadRootCertificatesFromFile` with `.WithRootCertificates(certs)` for Custom Root Certificates; `WithMutualTLS(cert, key)` for bytes and `WithMutualTLSFromFiles(certPath, keyPath, opts...)` with `config.WithReloadInterval(seconds uint32)` for paths. Plumbed via `NewAdvancedClusterClientConfiguration` and `NewAdvancedClientConfiguration`.

### Testing

Every Python, Java, Node.js, and Go sample was executed against a locally-built client (built from `main` in `valkey-io/valkey-glide`) and a local TLS rig: a 3-shard TLS Valkey cluster on ports 7001, 7002, 7003 and a TLS standalone Valkey on port 6390, both fronted by a self-signed CA generated with `openssl`.

For each of Python, Java, Node.js, and Go: Basic TLS (Cluster + Standalone), Insecure TLS (Cluster + Standalone), Custom Root Certificates (from PEM file, plus JKS/PKCS12 for Java), mTLS bytes, mTLS path (default reload cadence), mTLS path (custom reload interval), and mTLS via file loader all PASS with `PONG` returned from `ping`.

`pnpm build` runs successfully. Internal links validate.

### Checklist

- [x] This Pull Request documents shipped functionality across the linked source PRs.
- [x] Commit messages describe what changed and why.
- [x] All commits are signed off with `--signoff`.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct (main).
- [x] Create merge commit if merging release branch into main, squash otherwise.
