### PR TITLE
Add PHP circuit breaker examples

### DIFF
--- a/src/content/docs/how-to/connections/circuit-breaker.mdx
+++ b/src/content/docs/how-to/connections/circuit-breaker.mdx
@@ -92,9 +92,20 @@ The circuit breaker option is defined on the base client configuration, so it ap
   </TabItem>
 
   <TabItem label="PHP">
-    :::note
-    The circuit breaker is not yet available in the PHP client.
-    :::
+    ```php
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        circuit_breaker: [
+            'window_size_ms' => 10000,
+            'failure_rate_threshold' => 0.5,
+            'min_errors' => 50,
+            'open_timeout_ms' => 5000,
+            'count_timeouts' => false,
+            'consecutive_successes' => 3,
+        ]
+    );
+    ```
   </TabItem>
 
   <TabItem label="C#">
@@ -202,9 +213,13 @@ When the circuit breaker is open, requests throw immediately. Catch these except
   </TabItem>
 
   <TabItem label="PHP">
-    :::note
-    The circuit breaker is not yet available in the PHP client.
-    :::
+    ```php
+    try {
+        $value = $client->get("key");
+    } catch (CircuitBreakerException $e) {
+        // Circuit breaker is open — use fallback or back off
+    }
+    ```
   </TabItem>
 
   <TabItem label="C#">


### PR DESCRIPTION
### Summary

Add PHP code examples to the circuit breaker how-to guide, replacing the "not yet available" placeholders now that PHP support has been implemented.

### Issue link

This Pull Request is linked to issue (URL): [valkey-io/valkey-glide-php#238](https://github.com/valkey-io/valkey-glide-php/issues/238)

### Content Changes

- Replaced PHP "not yet available" note in the Configuration section with a working code example
- Replaced PHP "not yet available" note in the Handling Rejections section with a `CircuitBreakerException` catch example

### Implementation

PHP examples follow the same pattern as the other languages. The PHP client uses associative arrays for configuration (consistent with its existing API for compression, client-side cache, etc.) rather than a dedicated builder class.

### Testing

- Code examples verified against a running Valkey instance using the built PHP extension
- Visual review of tab rendering

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.