### PR TITLE
docs: mark RESET as available for PHP and C#

### DIFF
--- a/src/data/available-commands.json
+++ b/src/data/available-commands.json
@@ -97,7 +97,7 @@
       { "command": "HELLO", "valkey-io": "/commands/hello", "python": "available", "node": "available", "java": "available", "go": "available", "csharp": "available", "php": "available", "ruby": "available" },
       { "command": "PING", "valkey-io": "/commands/ping", "python": "available", "node": "available", "java": "available", "go": "available", "csharp": "available", "php": "available", "ruby": "available" },
       { "command": "QUIT", "valkey-io": "/commands/quit", "python": "not_available", "node": "not_available", "java": "not_available", "go": "not_available", "csharp": "not_available", "php": "not_available", "href": "#deprecated-commands", "ruby": "not_available" },
-      { "command": "RESET", "valkey-io": "/commands/reset", "python": "available", "node": "available", "java": "available", "go": "available", "csharp": "not_available", "php": "not_available", "csharp-href": "https://github.com/valkey-io/valkey-glide/issues/6292", "php-href": "https://github.com/valkey-io/valkey-glide/issues/6292", "ruby": "available" },
+      { "command": "RESET", "valkey-io": "/commands/reset", "python": "available", "node": "available", "java": "available", "go": "available", "csharp": "available", "php": "available", "ruby": "available" },
       { "command": "SELECT", "valkey-io": "/commands/select", "python": "available", "node": "available", "java": "available", "go": "available", "csharp": "available", "php": "available", "ruby": "available" }
     ]
   },


### PR DESCRIPTION
## Summary

Mark the RESET command as available for the PHP and C# clients in the command progress tracker.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`5d46e05`](https://github.com/valkey-io/valkey-glide-php/commit/5d46e05dcda437b34e2f651a9d174e51a1155a54) — Implement reset command (#273)
- [`81e15db`](https://github.com/valkey-io/valkey-glide-csharp/commit/81e15dbffe9e76ed5af3b4276197c05a85c2a2cb) — `RESET` command support (#457)

## Changes

- Updated `available-commands.json`: changed PHP status for RESET from `not_available` to `available`
- Removed the `php-href` tracking link since the command is now implemented
- Updated `available-commands.json`: changed C# status for RESET from `not_available` to `available`
- Removed the `csharp-href` tracking link since the command is now implemented

## Context

[Php #273](https://github.com/valkey-io/valkey-glide-php/pull/273) implements `reset()` for both standalone (`ValkeyGlide`) and cluster (`ValkeyGlideCluster`) PHP clients. The RESET command resets the connection's server-side state (subscriptions, watches, etc.) while keeping the connection alive.

[C# #457](https://github.com/valkey-io/valkey-glide-csharp/pull/457) implements `ResetAsync()` on `IBaseClient` for both standalone and cluster C# clients. In cluster mode, glide-core routes RESET to all nodes. Batch support is included via `IBatch.ResetAsync()` (non-atomic only; server rejects RESET inside MULTI/EXEC).

cc @prateek-kumar-improving @currantw

---

*This PR was generated by the automated documentation pipeline.*