### PR TITLE
docs: update platform requirements and MUSL support

### DIFF
--- a/src/content/docs/concepts/architecture/rust-core-design.mdx
+++ b/src/content/docs/concepts/architecture/rust-core-design.mdx
@@ -60,7 +60,7 @@ In general, each language binding is responsible for:
 * **Ensures Safety:** Prevents memory leaks and undefined behavior
 
 <Aside>
-  The FFI layer is implemented using language-specific FFI mechanisms, e.g. Py03 for Python or JNI (Java Native Interface) for Java.
+  The FFI layer is implemented using language-specific FFI mechanisms: PyO3 for Python, JNI (Java Native Interface) for Java, and NAPI-RS for Node.js.
 </Aside>
 
 ## The Rust Core

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -129,7 +129,7 @@ Windows support is currently available only for Valkey-GLIDE Java
   </TabItem>
 
   <TabItem label="Node">
-    **Requirements:** Node 16+
+    **Requirements:** Node 20+
 
     ```bash
     npm install @valkey/valkey-glide

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -89,7 +89,7 @@ The release of Valkey GLIDE was tested on the following platforms:
 
 <details>
   <summary>`glibc` requirements</summary>
-  Node.js requires `glibc` 2.17+. This should be the standard for GNU Linux based systems.
+  The Node.js native binaries require glibc 2.28+. This is standard for most modern GNU/Linux distributions (Ubuntu 20.04+, Amazon Linux 2023, RHEL 8+).
 
   However, to check you can use:
 
@@ -99,7 +99,7 @@ The release of Valkey GLIDE was tested on the following platforms:
 </details>
 
 :::caution
-Currently Alpine Linux / MUSL is NOT supported.
+Alpine Linux / MUSL support varies by language. Node.js and Java provide MUSL-compatible builds. Python does not currently support MUSL.
 :::
 
 ### MacOS
@@ -262,13 +262,9 @@ Windows support is currently available for Valkey GLIDE Java and C#.
   </TabItem>
 
   <TabItem label="Node">
-    **Requirements:** Node.js 16+
+    **Requirements:** Node.js 20+
 
     **For npm users on Linux it is recommended to use npm >=11**. It supports optional downloads based on libc. Yarn users should not be concerned.
-
-    :::note
-    The library is dependent on the [protobufjs library](https://protobufjs.github.io/protobuf.js/#installation), which adds size to the package. The package is using the protobufjs/minimal version, hence, if size matters, bundlers should be able to strip the unused code. It should reduce the size of the dependency from 19kb gzipped to 6.5kb gzipped.
-    :::
 
     To get started, Valkey GLIDE Node.js is available on npm for install.
 

--- a/src/content/docs/how-to/installation.mdx
+++ b/src/content/docs/how-to/installation.mdx
@@ -99,7 +99,7 @@ The release of Valkey GLIDE was tested on the following platforms:
 </details>
 
 :::caution
-Alpine Linux / MUSL support varies by language. Node.js and Java provide MUSL-compatible builds. Python does not currently support MUSL.
+Alpine Linux / MUSL support varies by language. Node.js, Java, and PHP provide MUSL-compatible builds. Python, Go, and C# do not currently support MUSL.
 :::
 
 ### MacOS
@@ -310,6 +310,14 @@ Windows support is currently available for Valkey GLIDE Java and C#.
     ```bash
     php -m | grep valkey_glide
     ```
+
+    :::note[Alpine Linux / MUSL]
+    The PHP extension supports Alpine Linux (musl libc 1.2.3+, Alpine 3.19+) on both x86_64 and aarch64. Building from source on Alpine requires additional packages:
+
+    ```bash
+    apk add cmake g++ perl linux-headers
+    ```
+    :::
   </TabItem>
 
   <TabItem label="C#">


### PR DESCRIPTION
## Summary

Update installation documentation to reflect MUSL/Alpine Linux support for Node.js, Java, and PHP.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`e2706b0`](https://github.com/valkey-io/valkey-glide/commit/e2706b00f69ac2660946f13350f41f85af64ca6c) — Node: Replace socket IPC with direct NAPI layer (#5325)
- [`9fcb478`](https://github.com/valkey-io/valkey-glide-php/commit/9fcb478415e4d0a8e8281885a8e231a5ccc22d54) — Add MUSL support ([Php #291](https://github.com/valkey-io/valkey-glide-php/pull/291))

## Changes

- Updated minimum Node.js version from 16+ to 20+ (installation and quickstart pages)
- Removed obsolete protobufjs dependency note (no longer used with NAPI-RS)
- Updated glibc requirement from 2.17+ to 2.28+ for Node.js native binaries
- Updated Alpine Linux/MUSL support status: now supported for Node.js, Java, and PHP
- Added Alpine/MUSL build note to PHP tab (required packages: cmake, g++, perl, linux-headers)
- Added NAPI-RS to the FFI layer description in the architecture docs
- Fixed typo: Py03 → PyO3

## Context

The Node.js client was rearchitected to replace Unix socket IPC + protobuf serialization with a direct NAPI-RS binding into the Rust core ([valkey-glide #5325](https://github.com/valkey-io/valkey-glide/pull/5325)). This changes the minimum supported Node.js version to 20, removes the protobuf dependency, and adds MUSL/Alpine Linux support via prebuilt native binaries.

The PHP extension now supports Alpine Linux (musl libc 1.2.3+, Alpine 3.19+) on x86_64 and aarch64 via build system changes ([Php #291](https://github.com/valkey-io/valkey-glide-php/pull/291)).

cc @avifenesh @prateek-kumar-improving

---

*This PR was generated by the automated documentation pipeline.*