### PR TITLE
docs: Java GlideString.asReadOnlyByteBuffer() API

### DIFF
--- a/src/content/docs/commands/valkey-string.mdx
+++ b/src/content/docs/commands/valkey-string.mdx
@@ -76,6 +76,29 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     client.get(gs(byteKey)).get();              // "GlideString value" as a GlideString
     client.get(gs(byteKey)).get().getString();  // "GlideString value" as a String
     ```
+
+    #### Zero-Copy Access
+
+    `GlideString` provides two ways to access the underlying bytes:
+
+    * `getBytes()` — returns a **defensive copy** of the byte array.
+    * `asReadOnlyByteBuffer()` — returns a read-only `java.nio.ByteBuffer` view of the underlying bytes **without copying**.
+
+    Use `asReadOnlyByteBuffer()` in high-performance scenarios where you need to read large binary values without allocation overhead. The returned buffer is read-only; attempting to write to it throws `ReadOnlyBufferException`.
+
+    ```java
+    GlideString gs = client.get(gs(byteKey)).get();
+
+    // Defensive copy (allocates a new byte[])
+    byte[] copied = gs.getBytes();
+
+    // Zero-copy read-only view (no allocation)
+    ByteBuffer buffer = gs.asReadOnlyByteBuffer();
+    byte[] data = new byte[buffer.remaining()];
+    buffer.get(data);
+
+    // buffer.isReadOnly() == true
+    ```
   </TabItem>
 
   <TabItem label="Node">


### PR DESCRIPTION
## Summary

Document the new `GlideString.asReadOnlyByteBuffer()` method added to the Java client, which provides zero-copy read access to the underlying bytes.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`5432e9e`](https://github.com/valkey-io/valkey-glide/commit/5432e9eded1d0c20aef33488b0f99cac8ff96f8e) — feat(java): add asReadOnlyByteBuffer in GlideString to return zero-copy (#6601)

## Changes

- Added "Zero-Copy Access" subsection to the Java tab in `commands/valkey-string.mdx`
- Documents `getBytes()` vs `asReadOnlyByteBuffer()` with usage examples
- Notes performance benefit and read-only constraint (`ReadOnlyBufferException`)

## Context

[PR #6601](https://github.com/valkey-io/valkey-glide/pull/6601) adds `asReadOnlyByteBuffer()` to `GlideString` in the Java client. This returns a read-only `ByteBuffer` view of the stored bytes without copying — useful for high-performance scenarios reading large binary values. The existing `getBytes()` continues returning a defensive copy for safety.

cc @jingyi-0

---

*This PR was generated by the automated documentation pipeline.*