### PR TITLE
Add Ruby examples to Learn, reference, and overview pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ GLIDE provides client implementations in multiple languages, all sharing a commo
 | Go       | https://github.com/valkey-io/valkey-glide/tree/main/go     |
 | C#       | https://github.com/valkey-io/valkey-glide-csharp           |
 | PHP      | https://github.com/valkey-io/valkey-glide-php              |
+| Ruby     | https://github.com/valkey-io/valkey-glide-ruby             |
 
 The core Rust engine lives at https://github.com/valkey-io/valkey-glide/tree/main/glide-core and provides the shared connection management, routing, and protocol logic that all language clients wrap.
 
@@ -116,18 +117,26 @@ Contains the automated audit of command implementations across all clients:
 - `ISSUE_CREATION_PLAN.md` — full plan for the issue creation workflow
 - Repos: `valkey-io/valkey-glide` (python/node/java/go), `valkey-io/valkey-glide-php`, `valkey-io/valkey-glide-csharp`
 
-### Local Source Repos (for verification)
-
-- Main (Python, Node.js, Java, Go): `../valkey-glide`
-- PHP: `../valkey-glide-php`
-- C#: `../valkey-glide-csharp`
-
 ## Content Guidelines
 
 - Each MDX page should have frontmatter with `title` and `description` fields
 - The `description` field is used for SEO and should be a concise summary of the page content
 - Internal links are validated at build time by `starlight-links-validator`
 - Use relative links for internal pages, not absolute URLs
+
+### Language Tabs
+
+Per-language code examples use Starlight tabs synced across pages:
+
+```mdx
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">...</TabItem>
+  ...
+</Tabs>
+```
+
+- Tab labels (in this order): `Python`, `Java`, `Node`, `Go`, `PHP`, `C#`, `Ruby`
+- Examples across tabs on the same page should be equivalent: same key names, values, hosts/ports, and flow
 
 ## Commit Requirements
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -369,6 +369,11 @@ export default defineConfig({
                   link: "https://github.com/valkey-io/valkey-glide-php/blob/main/valkey_glide.stub.php",
                   attrs: { style: "font-style: italic", target: "_blank" },
                 },
+                {
+                  label: "Ruby",
+                  link: "https://github.com/valkey-io/valkey-glide-ruby",
+                  attrs: { style: "font-style: italic", target: "_blank" },
+                },
               ],
             },
           ],

--- a/src/assets/ruby.svg
+++ b/src/assets/ruby.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" aria-hidden="true">
+  <path d="M7 4h10l4 5-9 11L3 9l4-5Z" />
+  <path d="M3 9h18M9.5 9 12 20 14.5 9M7 4l2.5 5L12 4l2.5 5L17 4" />
+</svg>

--- a/src/content/docs/commons/supported-languages-buttons.mdx
+++ b/src/content/docs/commons/supported-languages-buttons.mdx
@@ -5,6 +5,7 @@ pagefind: false
 
 import { LinkButton } from '@astrojs/starlight/components';
 import ButtonGroup from '../../../components/ButtonGroup.astro';
+import RubyIcon from '../../../assets/ruby.svg';
 
 <ButtonGroup>
   <LinkButton icon="seti:python" iconPlacement="start" href="/getting-started/quickstart?lang=python"> Python </LinkButton>
@@ -13,4 +14,9 @@ import ButtonGroup from '../../../components/ButtonGroup.astro';
   <LinkButton icon="seti:go" iconPlacement="start" href="/getting-started/quickstart?lang=go"> Go </LinkButton>
   <LinkButton icon="seti:c-sharp" iconPlacement="start" href="/getting-started/quickstart?lang=csharp"> C# </LinkButton>
   <LinkButton icon="seti:php" iconPlacement="start" href="/getting-started/quickstart?lang=php"> PHP </LinkButton>
+
+  <LinkButton href="/getting-started/quickstart?lang=ruby">
+    <RubyIcon />
+    Ruby
+  </LinkButton>
 </ButtonGroup>

--- a/src/content/docs/concepts/client-features/batch-commands.mdx
+++ b/src/content/docs/concepts/client-features/batch-commands.mdx
@@ -47,8 +47,10 @@ For **standalone** (non-cluster, cluster mode disabled) clients.
 
     # Create an atomic batch (transaction)
     batch = Batch(True)
+    batch.set("key", "value")
     # Create a non-atomic batch (pipeline)
-    batch = Batch(False)
+    pipeline = Batch(False)
+    pipeline.set("key", "value")
     ```
   </TabItem>
 
@@ -58,8 +60,10 @@ For **standalone** (non-cluster, cluster mode disabled) clients.
 
     // Create an atomic batch (transaction)
     Batch batch = new Batch(true);
+    batch.set("key", "value");
     // Create a non-atomic batch (pipeline)
     Batch pipeline = new Batch(false);
+    pipeline.set("key", "value");
     ```
   </TabItem>
 
@@ -68,9 +72,11 @@ For **standalone** (non-cluster, cluster mode disabled) clients.
     import {Batch} from "@valkey/valkey-glide";
 
     // Create an atomic batch (transaction)
-    const batch = new Batch(true)
+    const batch = new Batch(true);
+    batch.set("key", "value");
     // Create a non-atomic batch (pipeline)
-    const batch = new Batch(false)
+    const pipeline = new Batch(false);
+    pipeline.set("key", "value");
     ```
   </TabItem>
 
@@ -80,8 +86,10 @@ For **standalone** (non-cluster, cluster mode disabled) clients.
 
     // Create an atomic batch (transaction)
     transaction := pipeline.NewStandaloneBatch(true)
+    transaction.Set("key", "value")
     // Create a non-atomic batch (pipeline)
-    pipeline := pipeline.NewStandaloneBatch(false)
+    pipe := pipeline.NewStandaloneBatch(false)
+    pipe.Set("key", "value")
     ```
   </TabItem>
 
@@ -91,8 +99,24 @@ For **standalone** (non-cluster, cluster mode disabled) clients.
 
     // Create an atomic batch (transaction)
     var transaction = new Batch(true);
+    transaction.SetAsync("key", "value");
     // Create a non-atomic batch (pipeline)
     var pipeline = new Batch(false);
+    pipeline.SetAsync("key", "value");
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Atomic batch (transaction)
+    client.multi do |tx|
+      tx.set("key", "value")
+    end
+
+    # Non-atomic batch (pipeline)
+    client.pipelined do |pipe|
+      pipe.set("key", "value")
+    end
     ```
   </TabItem>
 </Tabs>
@@ -113,8 +137,10 @@ splitting into sub-pipelines if needed, [Read more in Multi-Node support](#multi
 
     # Create an atomic cluster batch (must use keys mapping to same slot)
     batch = ClusterBatch(True)
+    batch.set("key", "value")
     # Create a non-atomic cluster batch (pipeline may span multiple slots)
-    batch = ClusterBatch(False)
+    pipeline = ClusterBatch(False)
+    pipeline.set("key", "value")
     ```
   </TabItem>
 
@@ -124,8 +150,10 @@ splitting into sub-pipelines if needed, [Read more in Multi-Node support](#multi
 
     // Create an atomic cluster batch (must use keys mapping to same slot)
     ClusterBatch atomicCluster = new ClusterBatch(true);
+    atomicCluster.set("key", "value");
     // Create a non-atomic cluster batch (pipeline may span multiple slots)
     ClusterBatch pipelineCluster = new ClusterBatch(false);
+    pipelineCluster.set("key", "value");
     ```
   </TabItem>
 
@@ -134,9 +162,11 @@ splitting into sub-pipelines if needed, [Read more in Multi-Node support](#multi
     import {ClusterBatch} from "@valkey/valkey-glide";
 
     // Create an atomic cluster batch (must use keys mapping to same slot)
-    const batch = new ClusterBatch(true)
+    const batch = new ClusterBatch(true);
+    batch.set("key", "value");
     // Create a non-atomic cluster batch (pipeline may span multiple slots)
-    const batch = new ClusterBatch(false)
+    const pipeline = new ClusterBatch(false);
+    pipeline.set("key", "value");
     ```
   </TabItem>
 
@@ -146,8 +176,10 @@ splitting into sub-pipelines if needed, [Read more in Multi-Node support](#multi
 
     // Create an atomic cluster batch (must use keys mapping to same slot)
     transaction := pipeline.NewClusterBatch(true)
+    transaction.Set("key", "value")
     // Create a non-atomic cluster batch (pipeline may span multiple slots)
-    pipeline := pipeline.NewClusterBatch(false)
+    pipe := pipeline.NewClusterBatch(false)
+    pipe.Set("key", "value")
     ```
   </TabItem>
 
@@ -157,8 +189,24 @@ splitting into sub-pipelines if needed, [Read more in Multi-Node support](#multi
 
     // Create an atomic cluster batch (must use keys mapping to same slot)
     var transaction = new ClusterBatch(true);
+    transaction.SetAsync("key", "value");
     // Create a non-atomic cluster batch (pipeline may span multiple slots)
     var pipeline = new ClusterBatch(false);
+    pipeline.SetAsync("key", "value");
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Atomic cluster batch (must use keys mapping to same slot)
+    cluster_client.multi do |tx|
+      tx.set("key", "value")
+    end
+
+    # Non-atomic cluster batch (pipeline may span multiple slots)
+    cluster_client.pipelined do |pipe|
+      pipe.set("key", "value")
+    end
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -535,10 +535,9 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 ## Server-Assisted Invalidation
 
 Server-assisted invalidation can be enabled in the client side configuration by setting server assisted to true.
-You do not need to call [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) yourself; GLIDE issues `CLIENT TRACKING ON BCAST` on your behalf during connection setup. 
+You do not need to call [`CLIENT TRACKING`](https://valkey.io/commands/client-tracking/) yourself; GLIDE issues `CLIENT TRACKING ON BCAST` on your behalf during connection setup.
 
 Once enabled, the client receives push invalidation messages from the server whenever a cached key is modified, eliminating the staleness window inherent in TTL-only mode — the server notifies the client immediately when data changes, and the client removes the stale entry from its local cache.
-
 
 ### Enabling server-assisted mode
 

--- a/src/content/docs/concepts/client-features/custom-commands.mdx
+++ b/src/content/docs/concepts/client-features/custom-commands.mdx
@@ -9,6 +9,8 @@ The `custom_command` function is designed to execute a single command without ch
 
 :::note
 In PHP, this method is called `rawcommand()` instead of `custom_command`.
+
+In Ruby, this method is called `call` (or `call_v`, which takes the whole command as a single array) instead of `custom_command`.
 :::
 
 For `custom_command` examples, refer to the [Execute Custom Commands](/how-to/execute-custom-commands/) guide.

--- a/src/content/docs/concepts/client-features/valkey-scripting.mdx
+++ b/src/content/docs/concepts/client-features/valkey-scripting.mdx
@@ -5,7 +5,7 @@ description: Understanding how GLIDE handles Lua scripting, caching, and atomici
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Valkey GLIDE provide an interface for Valkey scripting allowing you to manage and execute
+Valkey GLIDE provide a scripting interface through the `Script` class, allowing you to manage and execute
 custom logic directly on the server. This page will explain how GLIDE handles Valkey scripting and its features.
 
 For more detail on just Valkey scripting, visit the Valkey [documentation](https://valkey.io/topics/eval-intro/).
@@ -17,9 +17,9 @@ with GLIDE, see our [guide](/how-to/load-and-execute-functions/).
 To learn more about Valkey Functions, see the Valkey [documentations](https://valkey.io/topics/functions-intro/).
 :::
 
-:::caution[Php Not Supported]
-The GLIDE Php client does not yet support this interface.
-To execute custom scripts, use the appropriate Php Valkey command API for executing and caching scripts.
+:::caution[Clients Not Supported]
+The GLIDE PHP and Ruby clients do not support the `Script` interface or `invokeScript()` method.
+To execute custom scripts, use the Valkey command API methods: `eval()`, `evalsha()`, `eval_ro()`, and `evalsha_ro()`.
 :::
 
 ## Key Benefits
@@ -131,6 +131,7 @@ Valkey GLIDE provides a `Script` class that wraps Valkey's [Lua](https://www.lua
     Console.WriteLine(result); // Hello, Valkey!
     ```
   </TabItem>
+
 </Tabs>
 
 ## Handling Inputs with KEYS and ARGV
@@ -210,15 +211,19 @@ Valkey provides `KEYS` and `ARGV` to handle input parameters:
     var config = new StandaloneClientConfigurationBuilder().Build();
     await using var client = await GlideClient.CreateClient(config);
 
+    var productKey = "product:shoe:stock";
+    var buyQuantity = "3";
+
     using var script = new Script("return redis.call('SET', KEYS[1], ARGV[1])");
 
     var options = new ScriptOptions()
-      .WithKeys("mykey")     // Maps to KEYS[1] in Lua
-      .WithArgs("myvalue"); // Maps to ARGV[1] in Lua
+      .WithKeys(productKey)    // Maps to KEYS[1] in Lua
+      .WithArgs(buyQuantity);  // Maps to ARGV[1] in Lua
 
     var result = await client.ScriptInvokeAsync(script, options);
     ```
   </TabItem>
+
 </Tabs>
 
 #### Why Use KEYS and ARGV
@@ -314,6 +319,7 @@ values directly into the script would create unique scripts each time, preventin
     var result = await client.ScriptInvokeAsync(goodScript, options);
     ```
   </TabItem>
+
 </Tabs>
 
 :::tip[Large Data]
@@ -366,6 +372,7 @@ GLIDE then automatically caches scripts with each `invoke_script()` call.
     Console.WriteLine($"Script hash: {script.Hash}"); // SHA1 hash of the script
     ```
   </TabItem>
+
 </Tabs>
 
 Scripts with identical code produce identical hashes, enabling efficient caching and reuse.
@@ -412,6 +419,7 @@ Scripts with identical code produce identical hashes, enabling efficient caching
     System.Diagnostics.Debug.Assert(script1.Hash == script2.Hash); // Same hash
     ```
   </TabItem>
+
 </Tabs>
 
 :::caution[Script hashing is content-sensitive]
@@ -553,6 +561,7 @@ When executing a script in cluster mode, all `KEYS` must belong to the same shar
             .WithArgs("John"));
     ```
   </TabItem>
+
 </Tabs>
 
 ### Explicit Routing
@@ -676,6 +685,7 @@ Adding a hash tag `{}` in the key allow you to specify the specific slot.
     var keys = new[] { "user:{1000}:name", "user:{1000}:email" };
     ```
   </TabItem>
+
 </Tabs>
 
 To lean more about hash tags, see the [documentation](https://valkey.io/topics/cluster-spec/#hash-tags).
@@ -787,6 +797,7 @@ To use Lua scripts within an atomic batch (MULTI/EXEC transaction), you must use
     Console.WriteLine($"GET result: {results[1]}");  // script-value
     ```
   </TabItem>
+
 </Tabs>
 
 ## What's Next

--- a/src/content/docs/getting-started/basic-operations.mdx
+++ b/src/content/docs/getting-started/basic-operations.mdx
@@ -187,6 +187,26 @@ To update keys in Valkey, clients can send [SET](https://valkey.io/commands/set/
     Console.WriteLine($"✓ Retrieved value: {value}");
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    client = Valkey.new(host: "localhost", port: 6379)
+
+    begin
+      # Set a key-value pair
+      client.set("user:1000", "john_doe")
+      puts "✓ Key set successfully"
+
+      # Get the value
+      value = client.get("user:1000")
+      puts "✓ Retrieved value: #{value}"
+    ensure
+      client.close
+    end
+    ```
+  </TabItem>
 </Tabs>
 
 ## Making Multiple Atomic Operations
@@ -302,6 +322,18 @@ Clients can send [MSET](https://valkey.io/commands/mset/) and [MGET](https://val
     Console.WriteLine($"✓ Retrieved values: {string.Join(", ", values)}");
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Set multiple keys at once
+    client.mapped_mset("user:1001" => "alice", "user:1002" => "bob", "user:1003" => "charlie")
+    puts "✓ Multiple keys set"
+
+    # Get multiple keys at once
+    values = client.mget("user:1001", "user:1002", "user:1003")
+    puts "✓ Retrieved values: #{values}"
+    ```
+  </TabItem>
 </Tabs>
 
 ## Removing Keys
@@ -359,6 +391,13 @@ Clients can also send [DEL](https://valkey.io/commands/del/) commands to delete 
 
     var count = await client.DeleteAsync(["user:1001", "user:1002", "user:1003"]);
     Console.WriteLine($"✓ Deleted {count} keys");
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    deleted_count = client.del("user:1001", "user:1002", "user:1003")
+    puts "✓ Deleted #{deleted_count} keys"
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -174,6 +174,20 @@ Windows support is currently available only for Valkey-GLIDE Java
     dotnet add package Valkey.Glide
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    **Requirements:** Ruby 2.6+
+
+    ```bash
+    gem install valkey-glide-rb
+    ```
+
+    Or add it to your `Gemfile`:
+
+    ```ruby
+    gem "valkey-glide-rb"
+    ```
+  </TabItem>
 </ParamTabs>
 
 :::tip[Installation Guides]
@@ -364,6 +378,28 @@ For testing against a live instance, update the `GlideClient` configurations.
     }
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    # Create the client
+    client = Valkey.new(host: "localhost", port: 6379)
+
+    begin
+      # Test the connection
+      response = client.ping
+
+      # Valkey responds with PONG
+      puts "Connected! Server responded: #{response}"
+    rescue StandardError => e
+      puts "Connection failed: #{e.message}"
+    ensure
+      # Always close the client
+      client.close
+    end
+    ```
+  </TabItem>
 </Tabs>
 
 Running the above snippet should give you this response.
@@ -494,6 +530,22 @@ These options, and other interfaces, stay consistent between languages.
         .Build();
 
     await using var client = await GlideClient.CreateClient(config);
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Setting up connection configuration
+    client = Valkey.new(
+      host: "localhost",
+      port: 6379,
+      # Request timeout (seconds)
+      timeout: 5.0,
+      # TLS configuration (if needed)
+      ssl: false,
+      # Database selection (0-15 for Redis/Valkey)
+      db: 0
+    )
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/reference/connection-options.mdx
+++ b/src/content/docs/reference/connection-options.mdx
@@ -23,6 +23,7 @@ The following are the configuration references for each Glide clients:
 | Go       | [Reference](https://pkg.go.dev/github.com/valkey-io/valkey-glide/go/v2/config#NewClientConfiguration) | [Reference](https://pkg.go.dev/github.com/valkey-io/valkey-glide/go/v2/config#NewClusterClientConfiguration) |
 | PHP      | [Reference](https://github.com/valkey-io/valkey-glide-php/blob/main/valkey_glide.stub.php#L360-L410)  | [Reference](https://github.com/valkey-io/valkey-glide-php/blob/main/valkey_glide_cluster.stub.php#L205-L270) |
 | C#       | [Reference](https://github.com/valkey-io/valkey-glide-csharp/blob/main/sources/Valkey.Glide/ConnectionConfiguration.cs) | [Reference](https://github.com/valkey-io/valkey-glide-csharp/blob/main/sources/Valkey.Glide/ConnectionConfiguration.cs) |
+| Ruby     | [Reference](https://github.com/valkey-io/valkey-glide-ruby/blob/main/README.md#connection-options-redis-rb-compatible) | [Reference](https://github.com/valkey-io/valkey-glide-ruby/blob/main/README.md#connection-options-redis-rb-compatible) |
 
 ### Example
 
@@ -103,6 +104,20 @@ The following are the configuration references for each Glide clients:
         .WithRequestTimeout(TimeSpan.FromMilliseconds(1000))
         .WithClientName("csharp_app")
         .Build();
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    client = Valkey.new(
+      host: "localhost",
+      port: 6379,
+      ssl: false,
+      timeout: 1.0,  # Request timeout in seconds
+      client_name: "ruby_app"
+    )
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/reference/scripting-reference.mdx
+++ b/src/content/docs/reference/scripting-reference.mdx
@@ -7,9 +7,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 This page contains code references for working with custom Lua scripts in Valkey GLIDE.
 
-:::caution[PHP Not Supported]
-The GLIDE PHP client does not support the `Script` interface or `invokeScript()` method.
-To execute custom scripts, use the PHP Valkey command API methods: `eval()`, `evalsha()`, `eval_ro()`, and `evalsha_ro()`.
+:::caution[Clients Not Supported]
+The GLIDE PHP and Ruby clients do not support the `Script` interface or `invokeScript()` method.
+To execute custom scripts, use the Valkey command API methods: `eval()`, `evalsha()`, `eval_ro()`, and `evalsha_ro()`.
 :::
 
 ## Migration from Direct EVAL
@@ -98,16 +98,6 @@ The following shows how to covert your `EVAL` command to GLIDE's `Script` interf
     ```
   </TabItem>
 
-  <TabItem label="PHP">
-    ```php
-    // PHP uses eval() method directly
-    $result = $client->eval(
-        "return redis.call('SET', KEYS[1], ARGV[1])",
-        ['mykey', 'myvalue'],
-        1  // num_keys
-    );
-    ```
-  </TabItem>
 </Tabs>
 
 ### Script Class (After)
@@ -189,12 +179,6 @@ The following shows how to covert your `EVAL` command to GLIDE's `Script` interf
     var options = new ScriptOptions().WithKeys("mykey").WithArgs("myvalue");
     var result = await client.ScriptInvokeAsync(script, options);
     ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    :::note
-    PHP does not support the `Script` class or `invokeScript()` method. Use `eval()` method as shown in the "Before" section.
-    :::
   </TabItem>
 </Tabs>
 
@@ -343,6 +327,20 @@ end
         ['rate_limit:user:123', '10', '60'],  // 10 requests per 60 seconds
         1  // num_keys
     );
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Read script from file
+    rate_limit = File.read("rate_limit.lua")
+
+    # Usage
+    result = client.eval(
+      rate_limit,
+      keys: ["rate_limit:user:123"],
+      args: ["10", "60"]  # 10 requests per 60 seconds
+    )
     ```
   </TabItem>
 </Tabs>
@@ -583,6 +581,34 @@ end
     }
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Read scripts from files
+    acquire_lock = File.read("acquire_lock.lua")
+    release_lock = File.read("release_lock.lua")
+
+    # Acquire lock
+    lock_acquired = client.eval(
+      acquire_lock,
+      keys: ["lock:resource:123"],
+      args: ["unique_token", "30"]  # 30 second expiration
+    )
+
+    if lock_acquired == 1
+      begin
+        # Do work while holding lock
+      ensure
+        # Release lock
+        client.eval(
+          release_lock,
+          keys: ["lock:resource:123"],
+          args: ["unique_token"]
+        )
+      end
+    end
+    ```
+  </TabItem>
 </Tabs>
 
 ### Conditional Update
@@ -713,6 +739,20 @@ end
         ['user:123:status', 'pending', 'active'],  // Change from "pending" to "active"
         1  // num_keys
     );
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Read script from file
+    conditional_update = File.read("conditional_update.lua")
+
+    # Update only if current value matches expected
+    updated = client.eval(
+      conditional_update,
+      keys: ["user:123:status"],
+      args: ["pending", "active"]  # Change from "pending" to "active"
+    )
     ```
   </TabItem>
 </Tabs>
@@ -873,6 +913,28 @@ end
             echo "Script error: $message\n";
         }
     }
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Handle script execution errors
+    script = "return redis.call('INCR', 'not_a_number')"
+
+    begin
+      result = client.eval(script)
+    rescue Valkey::CommandError => e
+      message = e.message
+      if message.include?("WRONGTYPE") || message.include?("not an integer")
+        puts "Type error in script"
+      elsif message.downcase.include?("syntax error")
+        puts "Lua syntax error in script"
+      elsif message.downcase.include?("unknown command")
+        puts "Invalid Redis command in script"
+      else
+        puts "Script error: #{message}"
+      end
+    end
     ```
   </TabItem>
 </Tabs>
@@ -1123,6 +1185,43 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     }
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    # Configure client timeout for long-running scripts
+    client = Valkey.new(
+      host: "localhost",
+      port: 6379,
+      timeout: 30.0  # 30 seconds for long scripts (default is 5.0)
+    )
+
+    # Handle long-running scripts
+    long_script = <<~LUA
+      local start = redis.call('TIME')[1]
+      while redis.call('TIME')[1] - start < 25 do
+          redis.call('GET', 'dummy_key')  -- Read-only operation
+      end
+      return 'Done'
+    LUA
+
+    begin
+      result = client.eval(long_script)
+      puts "Script completed: #{result}"
+    rescue Valkey::BaseError => e
+      message = e.message
+      if message.downcase.include?("timeout")
+        puts "Client timeout - script may still be running on server!"
+        puts "Consider increasing the timeout option in the client configuration"
+      elsif message.include?("Script killed")
+        puts "Script was killed by server (only possible for read-only scripts)"
+      else
+        puts "Script error: #{message}"
+      end
+    end
+    ```
+  </TabItem>
 </Tabs>
 
 ### Cluster-Specific Errors
@@ -1242,6 +1341,23 @@ When a client timeout occurs, the client stops waiting for a response, but the s
             // Use hash tags or route explicitly
         }
     }
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Handle cluster routing errors
+    begin
+      result = cluster_client.eval(
+        script,
+        keys: ["key1", "key2"]  # Might be in different slots
+      )
+    rescue Valkey::CommandError => e
+      if e.message.include?("CROSSSLOT")
+        puts "Keys are in different slots"
+        # Use hash tags or route explicitly
+      end
+    end
     ```
   </TabItem>
 </Tabs>
@@ -1423,6 +1539,31 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     );
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Good: Conditional update with multiple data structures
+    conditional_update = <<~LUA
+      local current = redis.call('GET', KEYS[1])
+      local threshold = tonumber(ARGV[2])
+
+      if current and tonumber(current) >= threshold then
+          redis.call('SET', KEYS[1], ARGV[1])
+          redis.call('LPUSH', KEYS[2], ARGV[1])
+          redis.call('EXPIRE', KEYS[2], ARGV[3])
+          return 1
+      else
+          return 0
+      end
+    LUA
+
+    result = client.eval(
+      conditional_update,
+      keys: ["user:score", "user:history"],
+      args: ["100", "50", "86400"]  # new score, threshold, expire in 1 day
+    )
+    ```
+  </TabItem>
 </Tabs>
 
 ### 2. Handle Nil Values Properly
@@ -1523,6 +1664,20 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     LUA;
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Good: Proper nil handling
+    safe_script = <<~LUA
+      local val = redis.call('GET', KEYS[1])
+      if val then
+          return val
+      else
+          return 'default_value'
+      end
+    LUA
+    ```
+  </TabItem>
 </Tabs>
 
 ### 3. Use Appropriate Data Types
@@ -1597,6 +1752,16 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     local value = redis.call('GET', KEYS[1])
     return tonumber(value) or 0  -- Ensure numeric return, default to 0 if nil
     LUA;
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Good: Return appropriate types
+    typed_script = <<~LUA
+      local value = redis.call('GET', KEYS[1])
+      return tonumber(value) or 0  -- Ensure numeric return, default to 0 if nil
+    LUA
     ```
   </TabItem>
 </Tabs>
@@ -1731,6 +1896,24 @@ When a client timeout occurs, the client stops waiting for a response, but the s
         ['user:{123}:name', 'user:{123}:email', 'John', 'john@example.com'],
         2  // num_keys
     );
+    ```
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    # Good: Use hash tags for related keys
+    cluster_script = <<~LUA
+      redis.call('SET', KEYS[1], ARGV[1])
+      redis.call('SET', KEYS[2], ARGV[2])
+      return 'OK'
+    LUA
+
+    # Execute with hash tags
+    cluster_client.eval(
+      cluster_script,
+      keys: ["user:{123}:name", "user:{123}:email"],
+      args: ["John", "john@example.com"]
+    )
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -193,6 +193,19 @@ To fix this, increase the **connection timeout** which is separate from the **re
     );
     ```
   </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    client = Valkey.new(
+      nodes: [{ host: "localhost", port: 6379 }],
+      cluster_mode: true,
+      timeout: 5.0,          # Request timeout in seconds
+      connect_timeout: 10.0  # Connection timeout in seconds
+    )
+    ```
+  </TabItem>
 </Tabs>
 
 ## Extension Not Loaded (PHP)


### PR DESCRIPTION
### Summary

Add documentations for Ruby client 1.0.0 release and covers:
- Homepage
- Overview
- Learn section
- Reference section

### Issue link

#300 

### Content Changes

- **Getting Started**: `quickstart`, `basic-operations` — Ruby tabs for
  install, standalone/cluster connection, and basic command examples.
- **Core Features (concepts)**: `batch-commands`, `custom-commands`,
  `valkey-scripting` — Ruby tabs for pipelining/transactions, `call`/`call_v`,
  and scripting.
- **Reference**: `connection-options` (Ruby option mapping), `scripting-reference`
- **Troubleshooting**: Ruby tab for the connection-timeout example.
- **Shared**: 
  - `supported-languages-buttons` 
  - New Ruby button 
  - `astro.config.mjs`
  -  Ruby entry in the API References sidebar; 
  - `AGENTS.md` Ruby in the supported-languages table plus language-tabs authoring guidance.

### Testing

- `pnpm build` runs successfully (110 pages, internal links validated).
- `pnpm format` applied.
- All added Ruby snippets executed against the real `1.0.0.pre.rc2` gem.
- Visual review of the language buttons on the homepage.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
