### PR TITLE
Fix set_then_get Lua function signatures

### DIFF
--- a/src/content/docs/how-to/load-and-execute-functions.mdx
+++ b/src/content/docs/how-to/load-and-execute-functions.mdx
@@ -26,9 +26,9 @@ The following example shows a simple example of loading and executing a Valkey F
 
          ```python
          lua_code = """#!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
+         server.register_function('set_then_get', function(keys, args)
+            server.call('SET', keys[1], args[1])
+            return server.call('GET', keys[1])
          end)
          """
          ```
@@ -89,9 +89,9 @@ The following example shows a simple example of loading and executing a Valkey F
          ```java
          String luaCode = """
          #!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
+         server.register_function('set_then_get', function(keys, args)
+            server.call('SET', keys[1], args[1])
+            return server.call('GET', keys[1])
          end)
          """;
          ```
@@ -162,9 +162,9 @@ The following example shows a simple example of loading and executing a Valkey F
 
          ```typescript
          const luaCode = `#!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
+         server.register_function('set_then_get', function(keys, args)
+            server.call('SET', keys[1], args[1])
+            return server.call('GET', keys[1])
          end)
          `;
          ```
@@ -226,9 +226,9 @@ The following example shows a simple example of loading and executing a Valkey F
 
          ```go
          luaCode := `#!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
+         server.register_function('set_then_get', function(keys, args)
+            server.call('SET', keys[1], args[1])
+            return server.call('GET', keys[1])
          end)
          `
          ```
@@ -360,9 +360,9 @@ The following example shows a simple example of loading and executing a Valkey F
          ```php
          $luaCode = <<<'LUA'
          #!lua name=example_module
-         server.register_function('set_then_get', function(key, value)
-            server.call('SET', key, value)
-            return server.call('GET', key)
+         server.register_function('set_then_get', function(keys, args)
+            server.call('SET', keys[1], args[1])
+            return server.call('GET', keys[1])
          end)
          LUA;
          ```

--- a/src/content/docs/how-to/load-and-execute-functions.mdx
+++ b/src/content/docs/how-to/load-and-execute-functions.mdx
@@ -417,9 +417,9 @@ The following example shows a simple example of loading and executing a Valkey F
          ```ruby
          lua_code = <<~LUA
            #!lua name=example_module
-           server.register_function('set_then_get', function(key, value)
-              server.call('SET', key, value)
-              return server.call('GET', key)
+           server.register_function('set_then_get', function(keys, args)
+              server.call('SET', keys[1], args[1])
+              return server.call('GET', keys[1])
            end)
          LUA
          ```


### PR DESCRIPTION
## Summary
Updates every `set_then_get` example to accept Valkey Functions’ `(keys, args)` arrays and index the first key and argument before calling `SET` and `GET`.

## Validation
- `pnpm run format:check:mdx`
- `pnpm build`
- `git diff --check`

## Checklist
- [x] Targets `main`
- [x] MDX formatting passes
- [x] Documentation build and internal-link validation pass
- [x] Commit includes DCO sign-off

Fixes #301