### PR TITLE
docs(node): add mTLS examples to TLS page

### DIFF
--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -678,8 +678,8 @@ Use `WithMutualTLS(cert, key)` (Go) or `useMutualTls(byte[], byte[])` (Java) whe
             tlsAdvancedConfiguration: {
                 mutualTls: {
                     kind: "bytes",
-                    certBytes: clientCert,
-                    keyBytes: clientKey,
+                    clientCertificate: clientCert,
+                    clientKey: clientKey,
                 },
             },
         },
@@ -797,8 +797,8 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
             tlsAdvancedConfiguration: {
                 mutualTls: {
                     kind: "path",
-                    certPath: "/path/to/client-cert.pem",
-                    keyPath: "/path/to/client-key.pem",
+                    clientCertPath: "/path/to/client-cert.pem",
+                    clientKeyPath: "/path/to/client-key.pem",
                 },
             },
         },
@@ -910,8 +910,8 @@ Pass a positive interval in seconds to override the core default. In Java, use `
             tlsAdvancedConfiguration: {
                 mutualTls: {
                     kind: "path",
-                    certPath: "/path/to/client-cert.pem",
-                    keyPath: "/path/to/client-key.pem",
+                    clientCertPath: "/path/to/client-cert.pem",
+                    clientKeyPath: "/path/to/client-key.pem",
                     reloadIntervalSeconds: 60,
                 },
             },
@@ -1037,8 +1037,8 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
             tlsAdvancedConfiguration: {
                 mutualTls: {
                     kind: "bytes",
-                    certBytes: cert,
-                    keyBytes: key,
+                    clientCertificate: cert,
+                    clientKey: key,
                 },
             },
         },
@@ -1116,7 +1116,8 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
 * **Sub-second and non-positive intervals are rejected:** in Go these fail with an error at configuration time.
   If you want static mTLS from files, load the bytes yourself using `LoadClientCertificateAndKeyFromFile` and use `WithMutualTLS(cert, key)`.
 * **mTLS still needs `use_tls=True`:** the advanced TLS configuration only fills in the client-side material and does not enable TLS by itself.
-* **Node.js `certBytes`/`keyBytes` must be non-empty:** proto3 `bytes` treats empty as unset, so GLIDE rejects empty `certBytes` or `keyBytes` at configuration time with a `ConfigurationError` rather than silently downgrading to server-auth-only TLS.
+* **Node.js `clientCertificate`/`clientKey` must be non-empty:** proto3 `bytes` treats empty as unset, so GLIDE rejects empty `clientCertificate` or `clientKey` at configuration time with a `ConfigurationError` rather than silently downgrading to server-auth-only TLS.
+* **Node.js `reloadIntervalSeconds` requires path-based mTLS:** setting `reloadIntervalSeconds` on a `kind: "bytes"` mTLS configuration is rejected with a `ConfigurationError` since byte-based material cannot be reloaded.
 * **Node.js `reloadIntervalSeconds` must be a positive integer ≤ 4,294,967,295:** protobufjs casts `uint32` via `value >>> 0`, so out-of-range values would silently truncate. GLIDE rejects them with a `ConfigurationError`.
 
 ### TLS Certificate Format

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -663,9 +663,28 @@ Use `WithMutualTLS(cert, key)` (Go) or `useMutualTls(byte[], byte[])` (Java) whe
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    // Load certificate and key from a secret store (not from source).
+    // The material is loaded once at connect time (static, no reload).
+    const clientCert: Buffer = /* PEM-encoded certificate bytes from a secret store */;
+    const clientKey: Buffer = /* PEM-encoded private key bytes from a secret store */;
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "bytes",
+                    certBytes: clientCert,
+                    keyBytes: clientKey,
+                },
+            },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -766,9 +785,25 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    // Point at cert/key files on disk.
+    // The core re-reads the material at its default cadence (300 seconds).
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "path",
+                    certPath: "/path/to/client-cert.pem",
+                    keyPath: "/path/to/client-key.pem",
+                },
+            },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -863,9 +898,26 @@ Pass a positive interval in seconds to override the core default. In Java, use `
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    // Point at cert/key files on disk with a custom reload interval.
+    // The core re-reads the material every 60 seconds.
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "path",
+                    certPath: "/path/to/client-cert.pem",
+                    keyPath: "/path/to/client-key.pem",
+                    reloadIntervalSeconds: 60,
+                },
+            },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -965,9 +1017,33 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
   </TabItem>
 
   <TabItem label="Node">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for Node.js is coming soon.
-    :::
+    ```typescript
+    import {
+        GlideClient,
+        loadClientCertificateAndKeyFromFile,
+    } from "@valkey/valkey-glide";
+
+    // Use the helper to load cert and key PEM bytes from disk.
+    const { cert, key } = await loadClientCertificateAndKeyFromFile(
+        "/path/to/client-cert.pem",
+        "/path/to/client-key.pem",
+    );
+
+    // Feed the loaded bytes to the in-memory mTLS mode (static, no reload).
+    const client = await GlideClient.createClient({
+        addresses: [{ host: "primary.example.com", port: 6379 }],
+        useTLS: true,
+        advancedConfiguration: {
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "bytes",
+                    certBytes: cert,
+                    keyBytes: key,
+                },
+            },
+        },
+    });
+    ```
   </TabItem>
 
   <TabItem label="Go">
@@ -1040,6 +1116,8 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
 * **Sub-second and non-positive intervals are rejected:** in Go these fail with an error at configuration time.
   If you want static mTLS from files, load the bytes yourself using `LoadClientCertificateAndKeyFromFile` and use `WithMutualTLS(cert, key)`.
 * **mTLS still needs `use_tls=True`:** the advanced TLS configuration only fills in the client-side material and does not enable TLS by itself.
+* **Node.js `certBytes`/`keyBytes` must be non-empty:** proto3 `bytes` treats empty as unset, so GLIDE rejects empty `certBytes` or `keyBytes` at configuration time with a `ConfigurationError` rather than silently downgrading to server-auth-only TLS.
+* **Node.js `reloadIntervalSeconds` must be a positive integer ≤ 4,294,967,295:** protobufjs casts `uint32` via `value >>> 0`, so out-of-range values would silently truncate. GLIDE rejects them with a `ConfigurationError`.
 
 ### TLS Certificate Format
 


### PR DESCRIPTION
## Summary

Adds Node.js code examples for all four mTLS subsections on the Configure TLS page, replacing the "Coming soon" placeholders. Uses the aligned field names shipped in valkey-glide#6678.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`4f74de2`](https://github.com/valkey-io/valkey-glide/commit/4f74de20b02acb14cd2e244006ea53637484271c) — feat(node): add mTLS client certificate/key support with automatic certificate reloading (#6383)
- [`15247fa`](https://github.com/valkey-io/valkey-glide/commit/15247fabf63f10a780db00db16a1688fc30b1191) — fix: bound mTLS cert reload interval and align Node field names across SDKs (#6678)

## Changes

- Replaced Node.js "Coming soon" placeholders in the mTLS section with complete code examples:
  - In-memory PEM (static) — `kind: "bytes"` with `clientCertificate` / `clientKey`
  - Path-based with automatic reload — `kind: "path"` with `clientCertPath` / `clientKeyPath`
  - Path-based with custom reload interval — `reloadIntervalSeconds: 60`
  - Loading PEM material from files — `loadClientCertificateAndKeyFromFile` helper
- Extended the Common Pitfalls section with Node.js-specific notes:
  - Empty `clientCertificate`/`clientKey` rejection
  - `reloadIntervalSeconds` rejected when paired with byte-based mTLS
  - uint32 interval range validation

## Context

Node.js mTLS support (both byte-based via discriminated union and path-based with automatic reload) shipped in [valkey-glide #6383](https://github.com/valkey-io/valkey-glide/pull/6383). The field names were subsequently aligned across all SDKs in [valkey-glide #6678](https://github.com/valkey-io/valkey-glide/pull/6678): `certBytes`/`keyBytes` → `clientCertificate`/`clientKey`, `certPath`/`keyPath` → `clientCertPath`/`clientKeyPath`. That same PR also bounded the reload interval and rejects `reloadIntervalSeconds` when combined with byte-based mTLS.

cc @xShinnRyuu

---

*This PR was generated by the automated documentation pipeline.*