### PR TITLE
docs: add periodic checks configuration page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -179,6 +179,7 @@ export default defineConfig({
                 "how-to/connections/circuit-breaker",
                 "how-to/connections/configure-lazy-connection",
                 "how-to/connections/limit-inflight-requests",
+                "how-to/connections/periodic-checks",
                 "how-to/connections/read-strategy",
                 "how-to/connections/resilience-best-practices",
                 "how-to/connections/timeouts-and-reconnect-strategy",

--- a/src/content/docs/how-to/connections/periodic-checks.mdx
+++ b/src/content/docs/how-to/connections/periodic-checks.mdx
@@ -10,13 +10,15 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
 
 ## Configuration Options
 
-| Option                              | Description                                                                                                |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **Enabled (Default)**               | Runs topology checks at the default 60 second interval.                                                    |
-| [Manual Interval](#manual-interval) | Runs topology checks at a custom interval.                                                                 |
-| [Disabled](#disabled)               | Turns off periodic checks. The client only refreshes topology on-demand in response to redirection errors. |
+| Option                | Description                                                                                                | How to set it                                                       |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Enabled (Default)** | Runs topology checks at the default 60 second interval.                                                    | Leave `periodicChecks` unset.                                       |
+| **Manual Interval**   | Runs topology checks at a custom interval.                                                                 | Set `periodicChecks` to a manual interval with a duration in seconds. |
+| **Disabled**          | Turns off periodic checks. The client only refreshes topology on-demand in response to redirection errors. | Set `periodicChecks` to disabled.                                   |
 
-## Manual Interval
+## Configuring
+
+The example below sets a custom interval of 30 seconds. Each snippet also shows, as a comment, how to disable periodic checks instead.
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="Python">
@@ -26,12 +28,14 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
         GlideClusterClientConfiguration,
         NodeAddress,
         PeriodicChecksManualInterval,
+        PeriodicChecksStatus,
     )
 
     addresses = [NodeAddress(host="address.example.com", port=6379)]
     client_config = GlideClusterClientConfiguration(
         addresses,
         periodic_checks=PeriodicChecksManualInterval(duration_in_sec=30),
+        # To disable instead: periodic_checks=PeriodicChecksStatus.DISABLED
     )
 
     client = await GlideClusterClient.create(client_config)
@@ -45,11 +49,13 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
     import glide.api.models.configuration.GlideClusterClientConfiguration;
     import glide.api.models.configuration.NodeAddress;
     import glide.api.models.configuration.PeriodicChecksManualInterval;
+    import glide.api.models.configuration.PeriodicChecksStatus;
 
     GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
         .address(NodeAddress.builder().host("address.example.com").port(6379).build())
         .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder()
             .periodicChecks(PeriodicChecksManualInterval.builder().durationInSec(30).build())
+            // To disable instead: .periodicChecks(PeriodicChecksStatus.DISABLED)
             .build())
         .build();
 
@@ -64,6 +70,7 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
     const client = await GlideClusterClient.createClient({
         addresses: [{ host: "address.example.com", port: 6379 }],
         periodicChecks: { duration_in_sec: 30 },
+        // To disable instead: periodicChecks: "disabled"
     });
     ```
   </TabItem>
@@ -77,9 +84,10 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
         "github.com/valkey-io/valkey-glide/go/v2/config"
     )
 
-    func ConnectClusterWithPeriodicChecksInterval() {
+    func ConnectClusterWithPeriodicChecks() {
         advancedConfig := config.NewAdvancedClusterClientConfiguration().
             WithPeriodicChecks(config.PeriodicChecksManualInterval{DurationInSec: 30})
+            // To disable instead: WithPeriodicChecks(config.PeriodicChecksDisabled{})
 
         myConfig := config.NewClusterClientConfiguration().
             WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
@@ -112,107 +120,7 @@ Periodic checks are enabled by default with a **60 second** interval. You can ke
       nodes: [{ host: "address.example.com", port: 6379 }],
       cluster_mode: true,
       periodic_checks: { manual_interval: { duration_in_sec: 30 } }
-    )
-    ```
-  </TabItem>
-</Tabs>
-
-## Disabled
-
-<Tabs syncKey="progLangInExamples">
-  <TabItem label="Python">
-    ```python
-    from glide import (
-        GlideClusterClient,
-        GlideClusterClientConfiguration,
-        NodeAddress,
-        PeriodicChecksStatus,
-    )
-
-    addresses = [NodeAddress(host="address.example.com", port=6379)]
-    client_config = GlideClusterClientConfiguration(
-        addresses,
-        periodic_checks=PeriodicChecksStatus.DISABLED,
-    )
-
-    client = await GlideClusterClient.create(client_config)
-    ```
-  </TabItem>
-
-  <TabItem label="Java">
-    ```java
-    import glide.api.GlideClusterClient;
-    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
-    import glide.api.models.configuration.GlideClusterClientConfiguration;
-    import glide.api.models.configuration.NodeAddress;
-    import glide.api.models.configuration.PeriodicChecksStatus;
-
-    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
-        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
-        .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder()
-            .periodicChecks(PeriodicChecksStatus.DISABLED)
-            .build())
-        .build();
-
-    GlideClusterClient client = GlideClusterClient.createClient(config).get();
-    ```
-  </TabItem>
-
-  <TabItem label="Node">
-    ```typescript
-    import { GlideClusterClient } from "@valkey/valkey-glide";
-
-    const client = await GlideClusterClient.createClient({
-        addresses: [{ host: "address.example.com", port: 6379 }],
-        periodicChecks: "disabled",
-    });
-    ```
-  </TabItem>
-
-  <TabItem label="Go">
-    ```go
-    import (
-        "context"
-
-        glide "github.com/valkey-io/valkey-glide/go/v2"
-        "github.com/valkey-io/valkey-glide/go/v2/config"
-    )
-
-    func ConnectClusterWithPeriodicChecksDisabled() {
-        advancedConfig := config.NewAdvancedClusterClientConfiguration().
-            WithPeriodicChecks(config.PeriodicChecksDisabled{})
-
-        myConfig := config.NewClusterClientConfiguration().
-            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
-            WithAdvancedConfiguration(advancedConfig)
-
-        client, _ := glide.NewClusterClient(myConfig)
-
-        client.Ping(context.Background())
-    }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    :::note
-    This feature is not yet available in GLIDE PHP.
-    :::
-  </TabItem>
-
-  <TabItem label="C#">
-    :::note
-    This feature is not yet available in GLIDE C#.
-    :::
-  </TabItem>
-
-  <TabItem label="Ruby">
-    ```ruby
-    require "valkey"
-
-    client = Valkey.new(
-      nodes: [{ host: "address.example.com", port: 6379 }],
-      cluster_mode: true,
-      periodic_checks: { disabled: true }
+      # To disable instead: periodic_checks: { disabled: true }
     )
     ```
   </TabItem>

--- a/src/content/docs/how-to/connections/periodic-checks.mdx
+++ b/src/content/docs/how-to/connections/periodic-checks.mdx
@@ -1,0 +1,219 @@
+---
+title: Configure Periodic Checks
+description: Guide for configuring periodic topology checks that keep a cluster client's view of the cluster up to date.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+In cluster mode, Valkey GLIDE periodically checks the cluster topology to detect changes and refreshes its internal slot map when a change is found.
+Periodic checks are enabled by default with a **60 second** interval. You can keep the default, set a custom interval, or disable them.
+
+## Configuration Options
+
+| Option                              | Description                                                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Enabled (Default)**               | Runs topology checks at the default 60 second interval.                                                    |
+| [Manual Interval](#manual-interval) | Runs topology checks at a custom interval.                                                                 |
+| [Disabled](#disabled)               | Turns off periodic checks. The client only refreshes topology on-demand in response to redirection errors. |
+
+## Manual Interval
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    from glide import (
+        GlideClusterClient,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        PeriodicChecksManualInterval,
+    )
+
+    addresses = [NodeAddress(host="address.example.com", port=6379)]
+    client_config = GlideClusterClientConfiguration(
+        addresses,
+        periodic_checks=PeriodicChecksManualInterval(duration_in_sec=30),
+    )
+
+    client = await GlideClusterClient.create(client_config)
+    ```
+  </TabItem>
+
+  <TabItem label="Java">
+    ```java
+    import glide.api.GlideClusterClient;
+    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+    import glide.api.models.configuration.GlideClusterClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.PeriodicChecksManualInterval;
+
+    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
+        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
+        .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder()
+            .periodicChecks(PeriodicChecksManualInterval.builder().durationInSec(30).build())
+            .build())
+        .build();
+
+    GlideClusterClient client = GlideClusterClient.createClient(config).get();
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        periodicChecks: { duration_in_sec: 30 },
+    });
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    import (
+        "context"
+
+        glide "github.com/valkey-io/valkey-glide/go/v2"
+        "github.com/valkey-io/valkey-glide/go/v2/config"
+    )
+
+    func ConnectClusterWithPeriodicChecksInterval() {
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithPeriodicChecks(config.PeriodicChecksManualInterval{DurationInSec: 30})
+
+        myConfig := config.NewClusterClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
+            WithAdvancedConfiguration(advancedConfig)
+
+        client, _ := glide.NewClusterClient(myConfig)
+
+        client.Ping(context.Background())
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    :::note
+    This feature is not yet available in GLIDE PHP.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note
+    This feature is not yet available in GLIDE C#.
+    :::
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    client = Valkey.new(
+      nodes: [{ host: "address.example.com", port: 6379 }],
+      cluster_mode: true,
+      periodic_checks: { manual_interval: { duration_in_sec: 30 } }
+    )
+    ```
+  </TabItem>
+</Tabs>
+
+## Disabled
+
+<Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    from glide import (
+        GlideClusterClient,
+        GlideClusterClientConfiguration,
+        NodeAddress,
+        PeriodicChecksStatus,
+    )
+
+    addresses = [NodeAddress(host="address.example.com", port=6379)]
+    client_config = GlideClusterClientConfiguration(
+        addresses,
+        periodic_checks=PeriodicChecksStatus.DISABLED,
+    )
+
+    client = await GlideClusterClient.create(client_config)
+    ```
+  </TabItem>
+
+  <TabItem label="Java">
+    ```java
+    import glide.api.GlideClusterClient;
+    import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+    import glide.api.models.configuration.GlideClusterClientConfiguration;
+    import glide.api.models.configuration.NodeAddress;
+    import glide.api.models.configuration.PeriodicChecksStatus;
+
+    GlideClusterClientConfiguration config = GlideClusterClientConfiguration.builder()
+        .address(NodeAddress.builder().host("address.example.com").port(6379).build())
+        .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder()
+            .periodicChecks(PeriodicChecksStatus.DISABLED)
+            .build())
+        .build();
+
+    GlideClusterClient client = GlideClusterClient.createClient(config).get();
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    import { GlideClusterClient } from "@valkey/valkey-glide";
+
+    const client = await GlideClusterClient.createClient({
+        addresses: [{ host: "address.example.com", port: 6379 }],
+        periodicChecks: "disabled",
+    });
+    ```
+  </TabItem>
+
+  <TabItem label="Go">
+    ```go
+    import (
+        "context"
+
+        glide "github.com/valkey-io/valkey-glide/go/v2"
+        "github.com/valkey-io/valkey-glide/go/v2/config"
+    )
+
+    func ConnectClusterWithPeriodicChecksDisabled() {
+        advancedConfig := config.NewAdvancedClusterClientConfiguration().
+            WithPeriodicChecks(config.PeriodicChecksDisabled{})
+
+        myConfig := config.NewClusterClientConfiguration().
+            WithAddress(&config.NodeAddress{Host: "address.example.com", Port: 6379}).
+            WithAdvancedConfiguration(advancedConfig)
+
+        client, _ := glide.NewClusterClient(myConfig)
+
+        client.Ping(context.Background())
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    :::note
+    This feature is not yet available in GLIDE PHP.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note
+    This feature is not yet available in GLIDE C#.
+    :::
+  </TabItem>
+
+  <TabItem label="Ruby">
+    ```ruby
+    require "valkey"
+
+    client = Valkey.new(
+      nodes: [{ host: "address.example.com", port: 6379 }],
+      cluster_mode: true,
+      periodic_checks: { disabled: true }
+    )
+    ```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
### Summary

Adds a new how-to guide, **Configure Periodic Checks**, documenting how to configure periodic cluster topology checks in Valkey GLIDE.

### Issue link

:white_circle: None

### Content Changes

- **New page** `src/content/docs/how-to/connections/periodic-checks.mdx`:
- **Sidebar** `astro.config.mjs`: adds the page to the "Connections" group, alphabetically ordered.

### Implementation

- Examples were verified against the [valkey-glide](https://github.com/valkey-io/valkey-glide) source and the language-specific repos to confirm exact API signatures and symbol exports.
- Tab order (`Python`, `Java`, `Node`, `Go`, `PHP`, `C#`, `Ruby`) and the `address.example.com:6379` host convention follow the existing connections pages.

### Limitations

- **PHP** and **C#** are marked "not yet available in GLIDE" for both options.

### Testing

- `pnpm build` runs successfully.
- `pnpm check` (build) reports all internal links valid.
- `pnpm format:check:mdx` passes with no unexpected warnings.

### Related Issues

:white_circle: None

### Checklist

Before submitting the PR make sure the following are checked:

- [x] ~~This Pull Request is related to one issue.~~ (docs addition, no tracking issue)
- [x] Commit message has a detailed description of what changed and why.
- [x] All commits are signed off with `--signoff` flag.
- [x] `pnpm build` runs successfully.
- [x] Links have been checked for validity.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
