### PR TITLE
docs(csharp): add inflight requests limit example

### DIFF
--- a/src/content/docs/how-to/connections/limit-inflight-requests.mdx
+++ b/src/content/docs/how-to/connections/limit-inflight-requests.mdx
@@ -13,9 +13,12 @@ Inflight requests limit can be configured through the general client configurati
 
 <Tabs syncKey="progLangInExamples">
   <TabItem label="C#">
-    :::note
-    This feature is not yet available in GLIDE C#.
-    :::
+    ```csharp
+    // Limit to 1000 inflight requests per connection
+    var clusterConfig = new GlideClusterClientConfiguration()
+        .WithAddress("address.example.com", 6379)
+        .WithInflightRequestsLimit(1000);
+    ```
   </TabItem>
 
   <TabItem label="Go">


### PR DESCRIPTION
## Summary

Add C# code example to the "Limit Inflight Requests" configuration page, replacing the "not yet available" placeholder.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`a83acbe`](https://github.com/valkey-io/valkey-glide-csharp/commit/a83acbe85401d8042fbfa09f0bf28092117418d4) — Add inflight requests limit configuration (#509)

## Changes

- Replaced C# "not yet available" placeholder in `how-to/connections/limit-inflight-requests.mdx` with a complete code example showing `WithInflightRequestsLimit(uint)` fluent builder usage on `GlideClusterClientConfiguration`

## Context

[C# #509](https://github.com/valkey-io/valkey-glide-csharp/pull/509) exposes the glide-core `inflight_requests_limit` configuration option through the C# client's `ClientConfigurationBuilder<T>`. The new `WithInflightRequestsLimit(uint)` fluent builder method allows users to control the maximum number of concurrent in-flight requests before new requests are rejected with `RequestException`. Setting the value to `0` throws `ArgumentOutOfRangeException`. If not set, the glide-core default (1000) is used.

cc @currantw

---

*This PR was generated by the automated documentation pipeline.*