### PR TITLE
docs: add C# periodic checks configuration example

### DIFF
--- a/src/content/docs/how-to/connections/periodic-checks.mdx
+++ b/src/content/docs/how-to/connections/periodic-checks.mdx
@@ -107,9 +107,17 @@ The example below sets a custom interval of 30 seconds. Each snippet also shows,
   </TabItem>
 
   <TabItem label="C#">
-    :::note
-    This feature is not yet available in GLIDE C#.
-    :::
+    ```csharp
+    using Valkey.Glide;
+
+    var config = new ClusterClientConfigurationBuilder()
+        .WithAddress("address.example.com", 6379)
+        .WithPeriodicChecks(TimeSpan.FromSeconds(30))
+        // To disable instead: .WithoutPeriodicChecks()
+        .Build();
+
+    var client = await GlideClusterClient.CreateClient(config);
+    ```
   </TabItem>
 
   <TabItem label="Ruby">


### PR DESCRIPTION
## Summary

Add C# code example to the periodic checks configuration page, replacing the "not yet available" placeholder now that the feature has been implemented in valkey-glide-csharp.

> ⚠️ **Attention:** This PR was generated automatically. Verify that all relevant pages have been updated.

## Source Commits

- [`f7784bd`](https://github.com/valkey-io/valkey-glide-csharp/commit/f7784bd15864f1629e3c27550c5da6dcd3e1fc3e) — Add periodic topology checks configuration for cluster client (#513)

## Changes

- Updated `src/content/docs/how-to/connections/periodic-checks.mdx`: replaced the C# "not yet available" note with a working code example demonstrating `WithPeriodicChecks(TimeSpan)` and `WithoutPeriodicChecks()` on `ClusterClientConfigurationBuilder`.

## Context

The C# GLIDE client now supports periodic topology checks configuration via [C# #513](https://github.com/valkey-io/valkey-glide-csharp/pull/513). The docs page for this feature was added in [docs #314](https://github.com/valkey-io/valkey-glide-docs/pull/314) but marked C# as "not yet available". This PR adds the C# example to match the implementation.

cc @currantw

---

*This PR was generated by the automated documentation pipeline.*