### PR TITLE
docs: standardize language tab ordering + enforce in CI

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check formatting
         run: pnpm format:check
 
+      - name: Check language tab ordering
+        run: pnpm check:tab-order
+
       - name: Build (will also check for internal links)
         run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ Per-language code examples use Starlight tabs synced across pages:
 ```
 
 - Tab labels (in this order): `Python`, `Java`, `Node`, `Go`, `PHP`, `C#`, `Ruby`
+- Languages a page doesn't cover are simply omitted; the remaining tabs keep this relative order
+- This order is enforced by `pnpm check:tab-order` (run in CI). The check lives at `scripts/check-tab-order.mjs` — update the `CANONICAL` array there if the order ever changes
 - Examples across tabs on the same page should be equivalent: same key names, values, hosts/ports, and flow
 
 ## Commit Requirements

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check:non-mdx": "prettier --check .",
     "format:check:mdx": "bash scripts/check-format.sh",
     "format:check": "pnpm run format:check:non-mdx && pnpm run format:check:mdx",
+    "check:tab-order": "node scripts/check-tab-order.mjs",
     "test-deploy": "pnpm build && ./test-deploy.sh"
   },
   "dependencies": {

--- a/scripts/check-tab-order.mjs
+++ b/scripts/check-tab-order.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Validates that language <TabItem> groups in the docs follow the canonical
+// ordering defined in AGENTS.md. Language tabs that are absent from a group are
+// simply skipped; a group is a violation only when the RELATIVE order of the
+// languages it does contain differs from the canonical order.
+//
+// Run: node scripts/check-tab-order.mjs   (also exposed as `pnpm check:tab-order`)
+// Exits non-zero and prints file:line for every offending <Tabs> group.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DOCS_DIR = join(ROOT, "src/content/docs");
+
+// Canonical order — keep in sync with the "Language Tabs" section of AGENTS.md.
+const CANONICAL = ["Python", "Java", "Node", "Go", "PHP", "C#", "Ruby"];
+const RANK = new Map(CANONICAL.map((lang, i) => [lang, i]));
+
+// Normalize label variants to their canonical key.
+function normalize(label) {
+  if (label === "Node.js") return "Node";
+  return label;
+}
+
+function isLanguage(label) {
+  return RANK.has(normalize(label));
+}
+
+function mdxFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...mdxFiles(full));
+    else if (entry.endsWith(".mdx") || entry.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+const ITEM_RE = /<TabItem\b[^>]*\blabel=(?:"([^"]*)"|'([^']*)')/g;
+
+// Parse a file into a list of tab groups. Uses a stack so that a <TabItem>
+// is attributed to its immediately enclosing <Tabs>, and nested tab groups
+// (e.g. build-tool tabs inside a language tab) are handled independently.
+function parseGroups(text) {
+  const lines = text.split("\n");
+  const stack = [];
+  const groups = [];
+  lines.forEach((line, idx) => {
+    // A single line can, in principle, contain multiple tokens; scan in order.
+    // We process opens/items/closes by their column position on the line.
+    const tokens = [];
+    let m;
+    const openRe = /<(?:Tabs|ParamTabs)\b/g;
+    while ((m = openRe.exec(line))) tokens.push({ col: m.index, type: "open" });
+    const closeRe = /<\/(?:Tabs|ParamTabs)>/g;
+    while ((m = closeRe.exec(line)))
+      tokens.push({ col: m.index, type: "close" });
+    ITEM_RE.lastIndex = 0;
+    while ((m = ITEM_RE.exec(line))) {
+      tokens.push({ col: m.index, type: "item", label: m[1] ?? m[2] });
+    }
+    tokens.sort((a, b) => a.col - b.col);
+    for (const t of tokens) {
+      if (t.type === "open") {
+        const g = { line: idx + 1, labels: [] };
+        stack.push(g);
+        groups.push(g);
+      } else if (t.type === "close") {
+        stack.pop();
+      } else if (t.type === "item") {
+        if (stack.length) stack[stack.length - 1].labels.push(t.label);
+      }
+    }
+  });
+  return groups;
+}
+
+function checkGroup(labels) {
+  const langs = labels.filter(isLanguage).map(normalize);
+  for (let i = 1; i < langs.length; i++) {
+    if (RANK.get(langs[i]) < RANK.get(langs[i - 1])) {
+      return langs; // out of order
+    }
+  }
+  return null;
+}
+
+let violations = 0;
+let filesWithViolations = 0;
+
+for (const file of mdxFiles(DOCS_DIR)) {
+  const text = readFileSync(file, "utf8");
+  const groups = parseGroups(text);
+  let fileHadViolation = false;
+  for (const g of groups) {
+    const bad = checkGroup(g.labels);
+    if (bad) {
+      if (!fileHadViolation) {
+        console.error(`\n${relative(ROOT, file)}`);
+        fileHadViolation = true;
+        filesWithViolations++;
+      }
+      const expected = [...bad].sort((a, b) => RANK.get(a) - RANK.get(b));
+      console.error(
+        `  line ${g.line}: [${bad.join(", ")}]  →  expected [${expected.join(", ")}]`,
+      );
+      violations++;
+    }
+  }
+}
+
+const canonicalStr = CANONICAL.join(" → ");
+if (violations > 0) {
+  console.error(
+    `\n✖ ${violations} tab group(s) in ${filesWithViolations} file(s) violate the canonical language order (${canonicalStr}).`,
+  );
+  process.exit(1);
+} else {
+  console.log(
+    `✓ All language tab groups follow the canonical order (${canonicalStr}).`,
+  );
+}

--- a/src/content/docs/commands/valkey-string.mdx
+++ b/src/content/docs/commands/valkey-string.mdx
@@ -194,6 +194,37 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     Go strings are immutable sequences of bytes and can safely represent binary data.
   </TabItem>
 
+  <TabItem label="PHP">
+    PHP uses native `string` type for all Valkey string operations. PHP strings are binary-safe and can contain arbitrary bytes.
+
+    #### Usage
+
+    Commands accept `string` arguments and return `string` or `mixed` values:
+
+    ```php
+    // Create client
+    $client = new ValkeyGlide();
+    $client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
+
+    // Using regular strings
+    $client->set('key', 'value');
+    $result = $client->get('key');  // Returns string: 'value'
+
+    // Using binary data - PHP strings are binary-safe
+    $binaryKey = "\x01\x02\x03\xFE";
+    $binaryValue = "\xDE\xAD\xBE\xEF";
+
+    $client->set($binaryKey, $binaryValue);
+    $result = $client->get($binaryKey);  // Returns binary string
+    ```
+
+    #### Type Handling
+
+    * PHP strings are binary-safe and can store any byte sequence
+    * No special type or conversion needed for binary data
+    * Commands return `string` for string values, `mixed` for commands that may return different types
+  </TabItem>
+
   <TabItem label="C#">
     C# uses `GlideString` as a wrapper type that can hold either a UTF-8 `string` or raw `byte[]` data.
 
@@ -259,36 +290,5 @@ Valkey strings store sequences of bytes, which may include text, serialized obje
     string[] strArr = gsArr1.ToStrings();       // to string[]
     byte[][] bytesArr = gsArr2.ToByteArrays();  // to byte[][]
     ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    PHP uses native `string` type for all Valkey string operations. PHP strings are binary-safe and can contain arbitrary bytes.
-
-    #### Usage
-
-    Commands accept `string` arguments and return `string` or `mixed` values:
-
-    ```php
-    // Create client
-    $client = new ValkeyGlide();
-    $client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
-
-    // Using regular strings
-    $client->set('key', 'value');
-    $result = $client->get('key');  // Returns string: 'value'
-
-    // Using binary data - PHP strings are binary-safe
-    $binaryKey = "\x01\x02\x03\xFE";
-    $binaryValue = "\xDE\xAD\xBE\xEF";
-
-    $client->set($binaryKey, $binaryValue);
-    $result = $client->get($binaryKey);  // Returns binary string
-    ```
-
-    #### Type Handling
-
-    * PHP strings are binary-safe and can store any byte sequence
-    * No special type or conversion needed for binary data
-    * Commands return `string` for string values, `mixed` for commands that may return different types
   </TabItem>
 </Tabs>

--- a/src/content/docs/concepts/architecture/async-execution.mdx
+++ b/src/content/docs/concepts/architecture/async-execution.mdx
@@ -46,17 +46,17 @@ To achieve this, each of GLIDE's clients supports the language's native asynchro
     :::
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    // Support Javascript Promises syntax
-    const status = await client.set("user:101", "active");
-    ```
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     // Async set operation using Future interface
     CompletableFuture<String> future = client.set("user:101", "active");
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    // Support Javascript Promises syntax
+    const status = await client.set("user:101", "active");
     ```
   </TabItem>
 

--- a/src/content/docs/concepts/architecture/memory-model.mdx
+++ b/src/content/docs/concepts/architecture/memory-model.mdx
@@ -61,6 +61,16 @@ Under steady load, the Rust core also holds:
 ## Language-Specific Notes
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    The Rust core's native memory is visible in process RSS but **not** reported
+    by `sys.getsizeof` or the `tracemalloc` module — those inspect Python
+    objects only. To observe total footprint use OS-level tools (`ps`,
+    `/proc/self/status`, container memory metrics, or `psutil`).
+
+    Python response objects (`bytes`, `str`, lists for multi-value replies) live
+    on the CPython heap and are subject to normal reference-counted reclamation.
+  </TabItem>
+
   <TabItem label="Java">
     GLIDE's Java client does **not** use JVM NIO direct (off-heap) buffers for
     network I/O. All socket reads and writes are performed in the Rust core;
@@ -79,16 +89,6 @@ Under steady load, the Rust core also holds:
     point.
   </TabItem>
 
-  <TabItem label="Python">
-    The Rust core's native memory is visible in process RSS but **not** reported
-    by `sys.getsizeof` or the `tracemalloc` module — those inspect Python
-    objects only. To observe total footprint use OS-level tools (`ps`,
-    `/proc/self/status`, container memory metrics, or `psutil`).
-
-    Python response objects (`bytes`, `str`, lists for multi-value replies) live
-    on the CPython heap and are subject to normal reference-counted reclamation.
-  </TabItem>
-
   <TabItem label="Node">
     The Rust core allocates outside the V8 heap; V8's `process.memoryUsage()`
     reports `rss` (which includes the native side) and `heapUsed` (which does
@@ -102,12 +102,6 @@ Under steady load, the Rust core also holds:
     (via its own allocator) is **not** visible in `runtime.MemStats` — those
     stats only track Go's own runtime allocations. Container sizing should be
     based on OS-reported RSS, not `MemStats.Sys`.
-  </TabItem>
-
-  <TabItem label="C#">
-    The Rust core's allocations are outside the managed heap and will not be
-    reported by `GC.GetTotalMemory`. Process-level counters
-    (`Process.WorkingSet64`, OS-level RSS) reflect the true footprint.
   </TabItem>
 
   <TabItem label="PHP">
@@ -126,6 +120,12 @@ Under steady load, the Rust core also holds:
     by the Rust core's push notification handler and queued into an unbounded
     linked list on the C side. If the PHP process does not consume messages
     promptly, this queue grows without limit.
+  </TabItem>
+
+  <TabItem label="C#">
+    The Rust core's allocations are outside the managed heap and will not be
+    reported by `GC.GetTotalMemory`. Process-level counters
+    (`Process.WorkingSet64`, OS-level RSS) reflect the true footprint.
   </TabItem>
 </Tabs>
 
@@ -172,6 +172,13 @@ expected.
 **From the runtime:**
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    import psutil, os
+    rss_mb = psutil.Process(os.getpid()).memory_info().rss / 1024 / 1024
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // JVM heap
@@ -183,13 +190,6 @@ expected.
     }
     // Enable NMT at startup with -XX:NativeMemoryTracking=summary
     // then: jcmd <pid> VM.native_memory summary
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```python
-    import psutil, os
-    rss_mb = psutil.Process(os.getpid()).memory_info().rss / 1024 / 1024
     ```
   </TabItem>
 
@@ -207,13 +207,6 @@ expected.
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using System.Diagnostics;
-    long rss = Process.GetCurrentProcess().WorkingSet64;
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     // emalloc-tracked memory only (excludes Rust core)
@@ -222,6 +215,13 @@ expected.
     $realMemory = memory_get_usage(true);
     // Peak real allocation
     $peakMemory = memory_get_peak_usage(true);
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using System.Diagnostics;
+    long rss = Process.GetCurrentProcess().WorkingSet64;
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/concepts/client-features/client-side-caching.mdx
+++ b/src/content/docs/concepts/client-features/client-side-caching.mdx
@@ -387,29 +387,6 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
     ```
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    // Both clients share the same cache
-    const cache = ClientSideCache.create(1024, 60000);
-
-    const client1 = await GlideClient.createClient({
-        addresses: [{ host: "localhost", port: 6379 }],
-        clientSideCache: cache,
-    });
-    const client2 = await GlideClient.createClient({
-        addresses: [{ host: "localhost", port: 6379 }],
-        clientSideCache: cache,
-    });
-
-    // client1 populates the cache
-    await client1.set("key", "value");
-    await client1.get("key");  // Cache miss — fetches from server
-
-    // client2 gets a cache hit without contacting the server
-    const result = await client2.get("key");  // Cache hit
-    ```
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     // Both clients share the same cache
@@ -438,6 +415,29 @@ Multiple clients can share the same cache instance by passing the same `ClientSi
 
     // client2 gets a cache hit without contacting the server
     String result = client2.get("key").get();  // Cache hit
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    // Both clients share the same cache
+    const cache = ClientSideCache.create(1024, 60000);
+
+    const client1 = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port: 6379 }],
+        clientSideCache: cache,
+    });
+    const client2 = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port: 6379 }],
+        clientSideCache: cache,
+    });
+
+    // client1 populates the cache
+    await client1.set("key", "value");
+    await client1.get("key");  // Cache miss — fetches from server
+
+    // client2 gets a cache hit without contacting the server
+    const result = await client2.get("key");  // Cache hit
     ```
   </TabItem>
 
@@ -542,6 +542,10 @@ Once enabled, the client receives push invalidation messages from the server whe
 ### Enabling server-assisted mode
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    Server-assisted invalidation is not yet available in the Python client. Progress is tracked in [issue #5963](https://github.com/valkey-io/valkey-glide/issues/5963).
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     import glide.api.GlideClient;
@@ -561,10 +565,6 @@ Once enabled, the client receives push invalidation messages from the server whe
         .build();
     GlideClient client = GlideClient.createClient(config).get();
     ```
-  </TabItem>
-
-  <TabItem label="Python">
-    Server-assisted invalidation is not yet available in the Python client. Progress is tracked in [issue #5963](https://github.com/valkey-io/valkey-glide/issues/5963).
   </TabItem>
 
   <TabItem label="Node">
@@ -593,6 +593,10 @@ Once enabled, the client receives push invalidation messages from the server whe
 The `clientTrackingInfo()` command returns the current tracking state of the connection. This is useful for verifying that server-assisted caching is active.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    Not yet available. See [issue #5963](https://github.com/valkey-io/valkey-glide/issues/5963).
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // Standalone client
@@ -608,10 +612,6 @@ The `clientTrackingInfo()` command returns the current tracking state of the con
     // Cluster client — query all nodes
     Map<String, Object> allNodesInfo = clusterClient.clientTrackingInfo(Route.ALL_NODES).get();
     ```
-  </TabItem>
-
-  <TabItem label="Python">
-    Not yet available. See [issue #5963](https://github.com/valkey-io/valkey-glide/issues/5963).
   </TabItem>
 
   <TabItem label="Node">

--- a/src/content/docs/concepts/client-features/cluster-scan.mdx
+++ b/src/content/docs/concepts/client-features/cluster-scan.mdx
@@ -40,6 +40,12 @@ To start iterating, create a `ClusterScanCursor`:
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $cursor = new ClusterScanCursor();
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -52,12 +58,6 @@ To start iterating, create a `ClusterScanCursor`:
     {
         Console.WriteLine($"Key: {key}");
     }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $cursor = new ClusterScanCursor();
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/compressing-data.mdx
+++ b/src/content/docs/how-to/compressing-data.mdx
@@ -97,6 +97,21 @@ When enabled, values are transparently compressed before being sent to the serve
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        compression: [
+            'enabled' => true,
+            'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
+            'compression_level' => 3,
+            'min_compression_size' => 128,
+        ],
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -113,21 +128,6 @@ When enabled, values are transparently compressed before being sent to the serve
         .Build();
 
     await using var client = await GlideClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client = new ValkeyGlide();
-    $client->connect(
-        addresses: [['host' => 'localhost', 'port' => 6379]],
-        compression: [
-            'enabled' => true,
-            'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
-            'compression_level' => 3,
-            'min_compression_size' => 128,
-        ],
-    );
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/connections/address-resolver.mdx
+++ b/src/content/docs/how-to/connections/address-resolver.mdx
@@ -119,25 +119,6 @@ Pass a callable to the address resolver parameter. The callable receives the ori
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-
-    var realHost = "127.0.0.1";
-    ushort realPort = 6379;
-
-    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder()
-        .WithAddress("host.unreachable", 9999)
-        .WithAddressResolver((host, port) => (realHost, realPort))
-        .Build();
-
-    await using var client = await GlideClient.CreateClient(config);
-
-    // Client is now connected to 127.0.0.1:6379
-    await client.SetAsync("key", "value");
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     $realHost = '127.0.0.1';
@@ -155,6 +136,25 @@ Pass a callable to the address resolver parameter. The callable receives the ori
 
     // Client is now connected to 127.0.0.1:6379
     $client->set('key', 'value');
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+
+    var realHost = "127.0.0.1";
+    ushort realPort = 6379;
+
+    var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder()
+        .WithAddress("host.unreachable", 9999)
+        .WithAddressResolver((host, port) => (realHost, realPort))
+        .Build();
+
+    await using var client = await GlideClient.CreateClient(config);
+
+    // Client is now connected to 127.0.0.1:6379
+    await client.SetAsync("key", "value");
     ```
   </TabItem>
 </Tabs>
@@ -252,6 +252,21 @@ If the resolver throws an exception or returns invalid data, the client falls ba
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // This resolver throws — the client will use the original address
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        address_resolver: function (string $host, int $port): array {
+            throw new \RuntimeException('Resolution failed');
+        },
+    );
+
+    // Still connects to localhost:6379
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -263,21 +278,6 @@ If the resolver throws an exception or returns invalid data, the client falls ba
         .Build();
 
     await using var client = await GlideClient.CreateClient(config);
-
-    // Still connects to localhost:6379
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // This resolver throws — the client will use the original address
-    $client = new ValkeyGlide();
-    $client->connect(
-        addresses: [['host' => 'localhost', 'port' => 6379]],
-        address_resolver: function (string $host, int $port): array {
-            throw new \RuntimeException('Resolution failed');
-        },
-    );
 
     // Still connects to localhost:6379
     ```
@@ -361,6 +361,17 @@ The cluster client supports the same resolver signature.
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $cluster = new ValkeyGlideCluster(
+        addresses: [['host' => 'internal-dns.service', 'port' => 7000]],
+        address_resolver: function (string $host, int $port): array {
+            return ['host' => getActualHost($host), 'port' => $port];
+        },
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -374,17 +385,6 @@ The cluster client supports the same resolver signature.
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $cluster = new ValkeyGlideCluster(
-        addresses: [['host' => 'internal-dns.service', 'port' => 7000]],
-        address_resolver: function (string $host, int $port): array {
-            return ['host' => getActualHost($host), 'port' => $port];
-        },
-    );
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/connections/configure-lazy-connection.mdx
+++ b/src/content/docs/how-to/connections/configure-lazy-connection.mdx
@@ -12,32 +12,6 @@ GLIDE supports **lazy connection mode**, which defers the establishment of physi
 Lazy connection can be configured through the client configuration object.
 
 <Tabs syncKey="progLangInExamples">
-  <TabItem label="Node">
-    ```typescript
-    import { GlideClient, GlideClusterClient } from "@valkey/valkey-glide";
-
-    // Standalone client with lazy connect
-    const standaloneClient = await GlideClient.createClient({
-        addresses: [{ host: "localhost", port: 6379 }],
-        lazyConnect: true,
-        requestTimeout: 5000
-    });
-
-    // Cluster client with lazy connect
-    const clusterClient = await GlideClusterClient.createClient({
-        addresses: [
-            { host: "localhost", port: 7000 },
-            { host: "localhost", port: 7001 }
-        ],
-        lazyConnect: true,
-        requestTimeout: 5000
-    });
-
-    // No connection established yet - this will trigger the connection
-    const result = await standaloneClient.ping();
-    ```
-  </TabItem>
-
   <TabItem label="Python">
     ```python
     from glide import GlideClient, GlideClusterClient, NodeAddress
@@ -98,6 +72,32 @@ Lazy connection can be configured through the client configuration object.
     ```
   </TabItem>
 
+  <TabItem label="Node">
+    ```typescript
+    import { GlideClient, GlideClusterClient } from "@valkey/valkey-glide";
+
+    // Standalone client with lazy connect
+    const standaloneClient = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port: 6379 }],
+        lazyConnect: true,
+        requestTimeout: 5000
+    });
+
+    // Cluster client with lazy connect
+    const clusterClient = await GlideClusterClient.createClient({
+        addresses: [
+            { host: "localhost", port: 7000 },
+            { host: "localhost", port: 7001 }
+        ],
+        lazyConnect: true,
+        requestTimeout: 5000
+    });
+
+    // No connection established yet - this will trigger the connection
+    const result = await standaloneClient.ping();
+    ```
+  </TabItem>
+
   <TabItem label="Go">
     ```go
     import (
@@ -133,6 +133,34 @@ Lazy connection can be configured through the client configuration object.
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Standalone client with lazy connect
+    $standaloneClient = new ValkeyGlide();
+    $standaloneClient->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        lazy_connect: true,
+        request_timeout: 5000
+    );
+
+    // Cluster client with lazy connect
+    $clusterClient = new ValkeyGlideCluster(
+        addresses: [
+            ['host' => 'localhost', 'port' => 7000],
+            ['host' => 'localhost', 'port' => 7001]
+        ],
+        lazy_connect: true,
+        request_timeout: 5000
+    );
+
+    // No connection established yet - this will trigger the connection
+    $result = $standaloneClient->ping();
+
+    $standaloneClient->close();
+    $clusterClient->close();
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -159,34 +187,6 @@ Lazy connection can be configured through the client configuration object.
 
     // No connection established yet - this will trigger the connection
     var result = await standaloneClient.PingAsync();
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Standalone client with lazy connect
-    $standaloneClient = new ValkeyGlide();
-    $standaloneClient->connect(
-        addresses: [['host' => 'localhost', 'port' => 6379]],
-        lazy_connect: true,
-        request_timeout: 5000
-    );
-
-    // Cluster client with lazy connect
-    $clusterClient = new ValkeyGlideCluster(
-        addresses: [
-            ['host' => 'localhost', 'port' => 7000],
-            ['host' => 'localhost', 'port' => 7001]
-        ],
-        lazy_connect: true,
-        request_timeout: 5000
-    );
-
-    // No connection established yet - this will trigger the connection
-    $result = $standaloneClient->ping();
-
-    $standaloneClient->close();
-    $clusterClient->close();
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/connections/limit-inflight-requests.mdx
+++ b/src/content/docs/how-to/connections/limit-inflight-requests.mdx
@@ -12,17 +12,12 @@ To ensure system stability and prevent out-of-memory (OOM) errors, Valkey GLIDE 
 Inflight requests limit can be configured through the general client configurations.
 
 <Tabs syncKey="progLangInExamples">
-  <TabItem label="C#">
-    :::note
-    This feature is not yet available in GLIDE C#.
-    :::
-  </TabItem>
-
-  <TabItem label="Go">
-    ```go
-    // Limit to 1000 inflight requests per connection
-    clusterConfig := config.NewClusterClientConfiguration().
-        WithInflightRequestsLimit(1000)
+  <TabItem label="Python">
+    ```python
+    # Limit to 1000 inflight requests per connection
+    cluster_config = GlideClusterClientConfiguration(
+        inflight_requests_limit=1000,
+    )
     ```
   </TabItem>
 
@@ -44,19 +39,24 @@ Inflight requests limit can be configured through the general client configurati
     ```
   </TabItem>
 
+  <TabItem label="Go">
+    ```go
+    // Limit to 1000 inflight requests per connection
+    clusterConfig := config.NewClusterClientConfiguration().
+        WithInflightRequestsLimit(1000)
+    ```
+  </TabItem>
+
   <TabItem label="PHP">
     :::note
     PHP GLIDE uses a synchronous blocking API, which means only one request can be in-flight at a time. Therefore, the inflight request limit configuration is not applicable and is not exposed in the PHP API.
     :::
   </TabItem>
 
-  <TabItem label="Python">
-    ```python
-    # Limit to 1000 inflight requests per connection
-    cluster_config = GlideClusterClientConfiguration(
-        inflight_requests_limit=1000,
-    )
-    ```
+  <TabItem label="C#">
+    :::note
+    This feature is not yet available in GLIDE C#.
+    :::
   </TabItem>
 
   <TabItem label="Ruby">

--- a/src/content/docs/how-to/connections/read-strategy.mdx
+++ b/src/content/docs/how-to/connections/read-strategy.mdx
@@ -107,6 +107,23 @@ Valkey GLIDE provides support for the following read strategies, allowing you to
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $addresses = [
+        ['host' => 'address.example.com', 'port' => 6379]
+    ];
+
+    $client = new ValkeyGlideCluster(
+        addresses: $addresses,
+        read_from: ValkeyGlide::READ_FROM_PREFER_REPLICA
+    );
+
+    $client->set('key1', 'val1');
+    // get will read from one of the replicas
+    $client->get('key1');
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -122,23 +139,6 @@ Valkey GLIDE provides support for the following read strategies, allowing you to
 
     // GetAsync will read from one of the replicas
     await client.GetAsync("key1");
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $addresses = [
-        ['host' => 'address.example.com', 'port' => 6379]
-    ];
-
-    $client = new ValkeyGlideCluster(
-        addresses: $addresses,
-        read_from: ValkeyGlide::READ_FROM_PREFER_REPLICA
-    );
-
-    $client->set('key1', 'val1');
-    // get will read from one of the replicas
-    $client->get('key1');
     ```
   </TabItem>
 
@@ -253,24 +253,6 @@ When using the AZ Affinity read strategy, the `clientAz` setting is required to 
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    var config = new ClusterClientConfigurationBuilder()
-        .WithAddress("address.example.com", 6379)
-        .WithReadFrom(new ReadFrom(ReadFromStrategy.AzAffinity, "us-east-1a"))
-        .Build();
-
-    await using var client = await GlideClusterClient.CreateClient(config);
-    await client.SetAsync("key1", "val1");
-
-    // GetAsync will read from one of the replicas in the same client's availability zone if they exist
-    await client.GetAsync("key1");
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     $addresses = [
@@ -286,6 +268,24 @@ When using the AZ Affinity read strategy, the `clientAz` setting is required to 
     $client->set('key1', 'val1');
     // get will read from one of the replicas in the same client's availability zone if they exist
     $client->get('key1');
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new ClusterClientConfigurationBuilder()
+        .WithAddress("address.example.com", 6379)
+        .WithReadFrom(new ReadFrom(ReadFromStrategy.AzAffinity, "us-east-1a"))
+        .Build();
+
+    await using var client = await GlideClusterClient.CreateClient(config);
+    await client.SetAsync("key1", "val1");
+
+    // GetAsync will read from one of the replicas in the same client's availability zone if they exist
+    await client.GetAsync("key1");
     ```
   </TabItem>
 
@@ -401,24 +401,6 @@ When using the AZ Affinity Replicas and Primary read strategy, the `clientAz` se
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    var config = new ClusterClientConfigurationBuilder()
-        .WithAddress("address.example.com", 6379)
-        .WithReadFrom(new ReadFrom(ReadFromStrategy.AzAffinityReplicasAndPrimary, "us-east-1a"))
-        .Build();
-
-    await using var client = await GlideClusterClient.CreateClient(config);
-    await client.SetAsync("key1", "val1");
-
-    // GetAsync will read from one of the replicas or the primary in the same client's availability zone if they exist
-    await client.GetAsync("key1");
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     $addresses = [
@@ -434,6 +416,24 @@ When using the AZ Affinity Replicas and Primary read strategy, the `clientAz` se
     $client->set('key1', 'val1');
     // get will read from one of the replicas or the primary in the same client's availability zone if they exist
     $client->get('key1');
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new ClusterClientConfigurationBuilder()
+        .WithAddress("address.example.com", 6379)
+        .WithReadFrom(new ReadFrom(ReadFromStrategy.AzAffinityReplicasAndPrimary, "us-east-1a"))
+        .Build();
+
+    await using var client = await GlideClusterClient.CreateClient(config);
+    await client.SetAsync("key1", "val1");
+
+    // GetAsync will read from one of the replicas or the primary in the same client's availability zone if they exist
+    await client.GetAsync("key1");
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/execute-custom-scripts.mdx
+++ b/src/content/docs/how-to/execute-custom-scripts.mdx
@@ -279,43 +279,6 @@ The following steps shows how to run a simple a custom Lua script using GLIDE.
     </details>
   </TabItem>
 
-  <TabItem label="C#">
-    <Steps>
-      1. Define the Lua script as a string.
-      2. Create a `Script` object with the Lua code.
-      3. Execute the script using `ScriptInvokeAsync`.
-    </Steps>
-
-    <details>
-      <summary>Full Example</summary>
-
-      ```csharp
-      using Valkey.Glide;
-      using static Valkey.Glide.ConnectionConfiguration;
-
-      var config = new StandaloneClientConfigurationBuilder().Build();
-      await using var client = await GlideClient.CreateClient(config);
-
-      // 1. Define the Lua script as a string
-      var lua = @"
-      server.call('SET', KEYS[1], ARGV[1])
-      return KEYS[1] .. ': ' .. server.call('GET', KEYS[1])
-      ";
-
-      // 2. Create a `Script` object with the Lua code.
-      using var script = new Script(lua);
-
-      // 3. Execute the script using `ScriptInvokeAsync`.
-      var options = new ScriptOptions()
-          .WithKeys("username")
-          .WithArgs("John Doe");
-      var result = await client.ScriptInvokeAsync(script, options);
-
-      Console.WriteLine(result); // username: John Doe
-      ```
-    </details>
-  </TabItem>
-
   <TabItem label="PHP">
     :::caution
     The `invokeScript` command is not supported in Valkey GLIDE PHP.
@@ -379,6 +342,43 @@ The following steps shows how to run a simple a custom Lua script using GLIDE.
     :::tip[Script API vs eval/evalSha]
     Other GLIDE clients provide a `Script` API that automatically handles script caching and SHA1 management. In PHP, you manually manage this using `eval()` and `evalsha()`. For detailed patterns and best practices, see the [Valkey Scripting Reference](/reference/scripting-reference).
     :::
+  </TabItem>
+
+  <TabItem label="C#">
+    <Steps>
+      1. Define the Lua script as a string.
+      2. Create a `Script` object with the Lua code.
+      3. Execute the script using `ScriptInvokeAsync`.
+    </Steps>
+
+    <details>
+      <summary>Full Example</summary>
+
+      ```csharp
+      using Valkey.Glide;
+      using static Valkey.Glide.ConnectionConfiguration;
+
+      var config = new StandaloneClientConfigurationBuilder().Build();
+      await using var client = await GlideClient.CreateClient(config);
+
+      // 1. Define the Lua script as a string
+      var lua = @"
+      server.call('SET', KEYS[1], ARGV[1])
+      return KEYS[1] .. ': ' .. server.call('GET', KEYS[1])
+      ";
+
+      // 2. Create a `Script` object with the Lua code.
+      using var script = new Script(lua);
+
+      // 3. Execute the script using `ScriptInvokeAsync`.
+      var options = new ScriptOptions()
+          .WithKeys("username")
+          .WithArgs("John Doe");
+      var result = await client.ScriptInvokeAsync(script, options);
+
+      Console.WriteLine(result); // username: John Doe
+      ```
+    </details>
   </TabItem>
 
   <TabItem label="Ruby">

--- a/src/content/docs/how-to/load-and-execute-functions.mdx
+++ b/src/content/docs/how-to/load-and-execute-functions.mdx
@@ -313,46 +313,6 @@ The following example shows a simple example of loading and executing a Valkey F
     </details>
   </TabItem>
 
-  <TabItem label="C#">
-    <Steps>
-      1. Define the Lua script as a string.
-      2. Load the function to Valkey using `FunctionLoadAsync`.
-      3. Call the function using `FCallAsync`.
-    </Steps>
-
-    <details>
-      <summary>Full Example</summary>
-
-      ```csharp
-      using Valkey.Glide;
-      using static Valkey.Glide.ConnectionConfiguration;
-
-      var config = new StandaloneClientConfigurationBuilder()
-          .WithAddress("localhost", 6379)
-          .Build();
-      await using var client = await GlideClient.CreateClient(config);
-
-      await client.SetAsync("page:home:visits", "0");
-
-      // 1. Define the Lua script as a string.
-      // lua code that updates a key and returns its new value
-      var luaCode = @"#!lua name=page_visits
-      server.register_function('update_visits', function(visits)
-          server.call('INCR', visits[1])
-          return server.call('GET', visits[1])
-      end)
-      ";
-
-      // 2. Load the function to Valkey using `FunctionLoadAsync`.
-      await client.FunctionLoadAsync(luaCode, replace: true);
-
-      // 3. Call the function using `FCallAsync`.
-      var result = await client.FCallAsync("update_visits", ["page:home:visits"], []);
-      Console.WriteLine(result); // 1
-      ```
-    </details>
-  </TabItem>
-
   <TabItem label="PHP">
     <Steps>
       1. Define the lua script.
@@ -406,6 +366,46 @@ The following example shows a simple example of loading and executing a Valkey F
       // calling the previously loaded function
       $result = $client->fcall('update_visits', ['page:home:visits']);
       echo $result;  // 1
+      ```
+    </details>
+  </TabItem>
+
+  <TabItem label="C#">
+    <Steps>
+      1. Define the Lua script as a string.
+      2. Load the function to Valkey using `FunctionLoadAsync`.
+      3. Call the function using `FCallAsync`.
+    </Steps>
+
+    <details>
+      <summary>Full Example</summary>
+
+      ```csharp
+      using Valkey.Glide;
+      using static Valkey.Glide.ConnectionConfiguration;
+
+      var config = new StandaloneClientConfigurationBuilder()
+          .WithAddress("localhost", 6379)
+          .Build();
+      await using var client = await GlideClient.CreateClient(config);
+
+      await client.SetAsync("page:home:visits", "0");
+
+      // 1. Define the Lua script as a string.
+      // lua code that updates a key and returns its new value
+      var luaCode = @"#!lua name=page_visits
+      server.register_function('update_visits', function(visits)
+          server.call('INCR', visits[1])
+          return server.call('GET', visits[1])
+      end)
+      ";
+
+      // 2. Load the function to Valkey using `FunctionLoadAsync`.
+      await client.FunctionLoadAsync(luaCode, replace: true);
+
+      // 3. Call the function using `FCallAsync`.
+      var result = await client.FCallAsync("update_visits", ["page:home:visits"], []);
+      Console.WriteLine(result); // 1
       ```
     </details>
   </TabItem>
@@ -558,6 +558,25 @@ GLIDE clients implement `FCALL_RO` command to execute read-only functions.
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $result = $client->fcall_ro('get_value', ['mykey']);
+    ```
+
+    **With Routing (Cluster Mode)**
+
+    ```php
+    // Route to all nodes
+    $result = $client->fcall_ro('get_value', [], [], 'allNodes');
+
+    // Route to all primary nodes
+    $result = $client->fcall_ro('get_value', [], [], 'allPrimaries');
+
+    // Route to a random node
+    $result = $client->fcall_ro('get_value', [], [], 'randomNode');
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -581,25 +600,6 @@ GLIDE clients implement `FCALL_RO` command to execute read-only functions.
     var allNodesResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.AllNodes);
     var allPrimariesResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.AllPrimaries);
     var randomResult = await clusterClient.FCallReadOnlyAsync("get_value", Route.Random);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $result = $client->fcall_ro('get_value', ['mykey']);
-    ```
-
-    **With Routing (Cluster Mode)**
-
-    ```php
-    // Route to all nodes
-    $result = $client->fcall_ro('get_value', [], [], 'allNodes');
-
-    // Route to all primary nodes
-    $result = $client->fcall_ro('get_value', [], [], 'allPrimaries');
-
-    // Route to a random node
-    $result = $client->fcall_ro('get_value', [], [], 'randomNode');
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/modules-api/json-module.mdx
+++ b/src/content/docs/how-to/modules-api/json-module.mdx
@@ -22,6 +22,32 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
 ## Examples
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    :::tip[API Reference]
+    The API reference can be found [here](https://glide.valkey.io/languages/python/api/reference/glide/async_commands/glide_json/).
+    :::
+
+    ```python
+    from glide import GlideClient, GlideClientConfiguration, NodeAddress, glide_json
+    import json
+
+    # Both standalone and cluster mode are supported
+    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
+    client = await GlideClient.create(config)
+    value = {'a': 1.0, 'b': 2}
+    json_str = json.dumps(value) # Convert Python dictionary to JSON string using json.dumps()
+
+    # Sets the value at `doc` as a JSON object.
+    set_response = await glide_json.set(client, "doc", "$", json_str)
+    print(set_response) # "OK" - Indicates successful setting of the value at path '$' in the key stored at `doc`.
+
+    # Gets the value at path '$' in the JSON document stored at `doc`.
+    get_response = await glide_json.get(client, "doc", "$") 
+    print(get_response) # b"[{\"a\":1.0,\"b\":2}]" 
+    json.loads(str(get_response)) # [{"a": 1.0, "b" :2}] - JSON object retrieved from the key `doc` using json.loads()
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     :::tip[API Reference]
     The API reference can be found [here](https://glide.valkey.io/languages/java/api/glide/api/commands/servermodules/Json.html).
@@ -77,32 +103,6 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
     // Gets the value at path '$' in the JSON document stored at `doc`.
     const jsonGetResponse = await GlideJson.get(client, "doc", {path: "$"});
     console.log(JSON.stringify(jsonGetResponse)); //  [{"a": 1.0, "b": 2}] # JSON object retrieved from the key `doc`
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    :::tip[API Reference]
-    The API reference can be found [here](https://glide.valkey.io/languages/python/api/reference/glide/async_commands/glide_json/).
-    :::
-
-    ```python
-    from glide import GlideClient, GlideClientConfiguration, NodeAddress, glide_json
-    import json
-
-    # Both standalone and cluster mode are supported
-    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
-    client = await GlideClient.create(config)
-    value = {'a': 1.0, 'b': 2}
-    json_str = json.dumps(value) # Convert Python dictionary to JSON string using json.dumps()
-
-    # Sets the value at `doc` as a JSON object.
-    set_response = await glide_json.set(client, "doc", "$", json_str)
-    print(set_response) # "OK" - Indicates successful setting of the value at path '$' in the key stored at `doc`.
-
-    # Gets the value at path '$' in the JSON document stored at `doc`.
-    get_response = await glide_json.get(client, "doc", "$") 
-    print(get_response) # b"[{\"a\":1.0,\"b\":2}]" 
-    json.loads(str(get_response)) # [{"a": 1.0, "b" :2}] - JSON object retrieved from the key `doc` using json.loads()
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/modules-api/search-module.mdx
+++ b/src/content/docs/how-to/modules-api/search-module.mdx
@@ -23,6 +23,68 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
 ## Examples
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    :::tip[API Reference]
+    The API reference can be found [here](https://glide.valkey.io/languages/python/api/reference/glide/async_commands/ft/).
+    :::
+
+    ```python
+    from glide import (
+        GlideClient,
+        GlideClientConfiguration,
+        NodeAddress,
+        ft,
+        glide_json,
+        DataType,
+        NumericField,
+        ReturnField,
+        FtCreateOptions,
+        FtSearchOptions,
+    )
+    import json
+    import time
+
+    # Both standalone and cluster mode are supported
+    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
+    client = await GlideClient.create(config)
+
+    prefix = "{json}:"
+    json_key1 = prefix + "1"
+    json_key2 = prefix + "2"
+    json_value1 = {"a": 11111, "b": 2, "c": 3}
+    json_value2 = {"a": 22222, "b": 2, "c": 3}
+    index = prefix + "index"
+
+    # FT.CREATE
+    await ft.create(
+        client,
+        index,
+        schema=[
+            NumericField("$.a", "a"),
+            NumericField("$.b", "b"),
+        ],
+        options=FtCreateOptions(data_type=DataType.JSON, prefixes=[prefix]),
+    )
+
+    await glide_json.set(client, json_key1, "$", json.dumps(json_value1))
+    await glide_json.set(client, json_key2, "$", json.dumps(json_value2))
+
+    time.sleep(1)  # let server digest the data and update index
+
+    # FT.SEARCH
+    ft_search_options = FtSearchOptions(
+        return_fields=[
+            ReturnField(field_identifier="a", alias="a_new"),
+            ReturnField(field_identifier="b", alias="b_new"),
+        ]
+    )
+
+    search_result = await ft.search(client, index, "@a:[-inf +inf]", options=ft_search_options)
+    # search_result[0] == 2
+    # search_result[1] contains results with "{json}:1" and "{json}:2"
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     :::tip[Javadoc]
     The API reference can be found [here](https://glide.valkey.io/languages/java/api/glide/api/commands/servermodules/FT.html).
@@ -148,68 +210,6 @@ Use `INFO MODULES` or `MODULE LIST` command to see the status of all loaded modu
     );
     console.log(searchResult[0]); // Output: 1
     console.log(searchResult[1]); // Output: search result containing "{json}:1"
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    :::tip[API Reference]
-    The API reference can be found [here](https://glide.valkey.io/languages/python/api/reference/glide/async_commands/ft/).
-    :::
-
-    ```python
-    from glide import (
-        GlideClient,
-        GlideClientConfiguration,
-        NodeAddress,
-        ft,
-        glide_json,
-        DataType,
-        NumericField,
-        ReturnField,
-        FtCreateOptions,
-        FtSearchOptions,
-    )
-    import json
-    import time
-
-    # Both standalone and cluster mode are supported
-    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
-    client = await GlideClient.create(config)
-
-    prefix = "{json}:"
-    json_key1 = prefix + "1"
-    json_key2 = prefix + "2"
-    json_value1 = {"a": 11111, "b": 2, "c": 3}
-    json_value2 = {"a": 22222, "b": 2, "c": 3}
-    index = prefix + "index"
-
-    # FT.CREATE
-    await ft.create(
-        client,
-        index,
-        schema=[
-            NumericField("$.a", "a"),
-            NumericField("$.b", "b"),
-        ],
-        options=FtCreateOptions(data_type=DataType.JSON, prefixes=[prefix]),
-    )
-
-    await glide_json.set(client, json_key1, "$", json.dumps(json_value1))
-    await glide_json.set(client, json_key2, "$", json.dumps(json_value2))
-
-    time.sleep(1)  # let server digest the data and update index
-
-    # FT.SEARCH
-    ft_search_options = FtSearchOptions(
-        return_fields=[
-            ReturnField(field_identifier="a", alias="a_new"),
-            ReturnField(field_identifier="b", alias="b_new"),
-        ]
-    )
-
-    search_result = await ft.search(client, index, "@a:[-inf +inf]", options=ft_search_options)
-    # search_result[0] == 2
-    # search_result[1] contains results with "{json}:1" and "{json}:2"
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/monitoring/logging.mdx
+++ b/src/content/docs/how-to/monitoring/logging.mdx
@@ -47,55 +47,6 @@ The following examples show how to configure the logger in GLIDE clients.
     Refer to the API [reference](https://glide.valkey.io/languages/python/api/glide_async/logger/?h=logger) for the full logger interface.
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    import { GlideClient, Logger } from "@valkey/valkey-glide";
-
-    // Configure the log level and the output file name.
-    Logger.setLoggerConfig("debug", "./glide_logs");
-
-    // Logging example
-    const message = "Hello World!";
-    const identifier = "LoggingExample";
-    Logger.log("info", identifier, message);
-
-    // Standalone client configuration
-    const addresses = [{ host: "localhost", port: 6379 }];
-    const client = await GlideClient.createClient({
-      addresses: addresses,
-    });
-
-    await client.ping();
-
-    ```
-
-    Refer to the API [reference](https://glide.valkey.io/languages/nodejs/api/classes/Logger.Logger.html) for the full logger interface.
-  </TabItem>
-
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    // Configure the log level and the output file name.
-    Logger.SetLoggerConfig(Level.Debug, "./glide_logs");
-
-    // Logging example
-    Logger.Log(Level.Info, "LoggingExample", "Hello World!");
-
-    // Standalone client configuration
-    var config = new StandaloneClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
-        .Build();
-
-    // Create a standalone client
-    await using var client = await GlideClient.CreateClient(config);
-    await client.PingAsync();
-    ```
-
-    Refer to the API [reference](https://github.com/valkey-io/valkey-glide-csharp/blob/main/sources/Valkey.Glide/Logger.cs#L33) for the full logger interface.
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     package com.example;
@@ -140,6 +91,31 @@ The following examples show how to configure the logger in GLIDE clients.
     Refer to the API [reference](https://glide.valkey.io/languages/java/api/glide/api/logging/Logger.html) for the full logger interface.
   </TabItem>
 
+  <TabItem label="Node">
+    ```typescript
+    import { GlideClient, Logger } from "@valkey/valkey-glide";
+
+    // Configure the log level and the output file name.
+    Logger.setLoggerConfig("debug", "./glide_logs");
+
+    // Logging example
+    const message = "Hello World!";
+    const identifier = "LoggingExample";
+    Logger.log("info", identifier, message);
+
+    // Standalone client configuration
+    const addresses = [{ host: "localhost", port: 6379 }];
+    const client = await GlideClient.createClient({
+      addresses: addresses,
+    });
+
+    await client.ping();
+
+    ```
+
+    Refer to the API [reference](https://glide.valkey.io/languages/nodejs/api/classes/Logger.Logger.html) for the full logger interface.
+  </TabItem>
+
   <TabItem label="PHP">
     ```php
     // Configure the log level and the output file name
@@ -160,6 +136,30 @@ The following examples show how to configure the logger in GLIDE clients.
     ```
 
     Refer to the [logger functions](https://github.com/valkey-io/valkey-glide-php/blob/main/logger.stub.php) for the full logger interface.
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    // Configure the log level and the output file name.
+    Logger.SetLoggerConfig(Level.Debug, "./glide_logs");
+
+    // Logging example
+    Logger.Log(Level.Info, "LoggingExample", "Hello World!");
+
+    // Standalone client configuration
+    var config = new StandaloneClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .Build();
+
+    // Create a standalone client
+    await using var client = await GlideClient.CreateClient(config);
+    await client.PingAsync();
+    ```
+
+    Refer to the API [reference](https://github.com/valkey-io/valkey-glide-csharp/blob/main/sources/Valkey.Glide/Logger.cs#L33) for the full logger interface.
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/how-to/monitoring/monitor-command.mdx
+++ b/src/content/docs/how-to/monitoring/monitor-command.mdx
@@ -48,22 +48,6 @@ There are two modes for consuming monitor messages:
     ```
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    import { GlideMonitorClient, MonitorLine } from "@valkey/valkey-glide";
-
-    const monitor = await GlideMonitorClient.create(
-      { addresses: [{ host: "localhost", port: 6379 }] },
-      (line: MonitorLine) => {
-        console.log(`${line.timestamp} [${line.db}] ${line.clientAddr} ${line.command} ${line.args.join(" ")}`);
-      },
-    );
-
-    // Close when done.
-    await monitor.close();
-    ```
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     import glide.api.MonitorClient;
@@ -81,6 +65,22 @@ There are two modes for consuming monitor messages:
         // Run commands on a separate client — the callback will print each one.
         Thread.sleep(5000);
     }
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    import { GlideMonitorClient, MonitorLine } from "@valkey/valkey-glide";
+
+    const monitor = await GlideMonitorClient.create(
+      { addresses: [{ host: "localhost", port: 6379 }] },
+      (line: MonitorLine) => {
+        console.log(`${line.timestamp} [${line.db}] ${line.clientAddr} ${line.command} ${line.args.join(" ")}`);
+      },
+    );
+
+    // Close when done.
+    await monitor.close();
     ```
   </TabItem>
 
@@ -134,21 +134,6 @@ There are two modes for consuming monitor messages:
     ```
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    import { GlideMonitorClient } from "@valkey/valkey-glide";
-
-    const monitor = await GlideMonitorClient.create({
-      addresses: [{ host: "localhost", port: 6379 }],
-    });
-
-    const line = await monitor.getNextMessage();
-    console.log(`${line.command} ${line.args.join(" ")}`);
-
-    await monitor.close();
-    ```
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     import glide.api.MonitorClient;
@@ -164,6 +149,21 @@ There are two modes for consuming monitor messages:
         MonitorMsg msg = monitor.getMonitorMessage();
         System.out.printf("%s %s%n", msg.command(), msg.args());
     }
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    import { GlideMonitorClient } from "@valkey/valkey-glide";
+
+    const monitor = await GlideMonitorClient.create({
+      addresses: [{ host: "localhost", port: 6379 }],
+    });
+
+    const line = await monitor.getNextMessage();
+    console.log(`${line.command} ${line.args.join(" ")}`);
+
+    await monitor.close();
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/monitoring/open-telemetry.mdx
+++ b/src/content/docs/how-to/monitoring/open-telemetry.mdx
@@ -109,29 +109,6 @@ GLIDE does not export data directly to third-party services—instead, it sends 
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-
-    OpenTelemetry.Init(
-        OpenTelemetryConfig.CreateBuilder()
-            .WithTraces(
-                TracesConfig.CreateBuilder()
-                    .WithEndpoint("http://localhost:4318/v1/traces")
-                    .WithSamplePercentage(10) // Optional, defaults to 1. Can also be changed at runtime via SetSamplePercentage().
-                    .Build()
-            )
-            .WithMetrics(
-                MetricsConfig.CreateBuilder()
-                    .WithEndpoint("http://localhost:4318/v1/metrics")
-                    .Build()
-            )
-            .WithFlushInterval(TimeSpan.FromSeconds(1)) // Optional, defaults to 5000 ms
-            .Build()
-    );
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     use ValkeyGlide\OpenTelemetry\{OpenTelemetryConfig, TracesConfig, MetricsConfig};
@@ -156,6 +133,29 @@ GLIDE does not export data directly to third-party services—instead, it sends 
     $client->connect(
         addresses: [['host' => 'localhost', 'port' => 6379]],
         advanced_config: ['otel' => $otelConfig]
+    );
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+
+    OpenTelemetry.Init(
+        OpenTelemetryConfig.CreateBuilder()
+            .WithTraces(
+                TracesConfig.CreateBuilder()
+                    .WithEndpoint("http://localhost:4318/v1/traces")
+                    .WithSamplePercentage(10) // Optional, defaults to 1. Can also be changed at runtime via SetSamplePercentage().
+                    .Build()
+            )
+            .WithMetrics(
+                MetricsConfig.CreateBuilder()
+                    .WithEndpoint("http://localhost:4318/v1/metrics")
+                    .Build()
+            )
+            .WithFlushInterval(TimeSpan.FromSeconds(1)) // Optional, defaults to 5000 ms
+            .Build()
     );
     ```
   </TabItem>

--- a/src/content/docs/how-to/monitoring/tracking-resources.mdx
+++ b/src/content/docs/how-to/monitoring/tracking-resources.mdx
@@ -105,12 +105,6 @@ GLIDE 1.2 introduces a new non-Valkey API: `getStatistics` which returns statist
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    :::note[Coming soon]
-    Statistics API documentation for C# is coming soon.
-    :::
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     $addresses = [
@@ -129,6 +123,12 @@ GLIDE 1.2 introduces a new non-Valkey API: `getStatistics` which returns statist
     echo "Total Connections: {$stats['total_connections']}\n";
     echo "Total Clients: {$stats['total_clients']}\n";
     ```
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note[Coming soon]
+    Statistics API documentation for C# is coming soon.
+    :::
   </TabItem>
 
   <TabItem label="Ruby">

--- a/src/content/docs/how-to/publish-and-subscribe-messages.mdx
+++ b/src/content/docs/how-to/publish-and-subscribe-messages.mdx
@@ -26,6 +26,19 @@ Since the RESP protocol does not guarantee strong delivery semantics for PubSub 
 To publish a message, create a separate client to your Valkey instance. Both Standalone and Cluster are supported.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    publisher_config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)]
+    )
+
+    publisher = await GlideClient.create(publisher_config)
+
+    # Publish message on 'ch1' channel
+    await publisher.publish("Test message", "ch1")
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     GlideClientConfiguration publisherConfig = GlideClientConfiguration.builder()
@@ -49,19 +62,6 @@ To publish a message, create a separate client to your Valkey instance. Both Sta
     await publisher.publish("Test message", "ch1");
 
     publisher.close();
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    publisher_config = GlideClientConfiguration(
-        [NodeAddress("localhost", 6379)]
-    )
-
-    publisher = await GlideClient.create(publisher_config)
-
-    # Publish message on 'ch1' channel
-    await publisher.publish("Test message", "ch1")
     ```
   </TabItem>
 
@@ -116,6 +116,41 @@ Starting with GLIDE 2.3, you can subscribe to channels and patterns at any point
 No special configuration is needed at client creation time — you can subscribe dynamically on any client. Messages are buffered and retrievable via polling by default. If you want callback-based delivery instead (explained [below](#callback)), provide a subscription configuration with a callback at client creation time (the initial channel set can be empty).
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    # Create a regular client — no subscription configuration needed
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+    )
+    client = await GlideClient.create(config)
+
+    # --- Exact channel subscriptions ---
+
+    # Blocking: waits up to 5000ms for server confirmation
+    await client.subscribe({"news", "updates"}, timeout_ms=5000)
+
+    # Non-blocking (lazy): returns immediately, subscribes in background
+    await client.subscribe_lazy({"alerts"})
+
+    # --- Pattern subscriptions ---
+
+    # Blocking
+    await client.psubscribe({"chat*", "event*"}, timeout_ms=5000)
+
+    # Non-blocking (lazy)
+    await client.psubscribe_lazy({"log*"})
+
+    # --- Sharded subscriptions (cluster mode only) ---
+    # await cluster_client.ssubscribe({"shard-ch1"}, timeout_ms=5000)
+    # await cluster_client.ssubscribe_lazy({"shard-ch2"})
+
+    # Retrieve messages via polling
+    msg = await client.get_pubsub_message()
+
+    await client.close()
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // Create a regular client — no subscription configuration needed
@@ -185,41 +220,6 @@ No special configuration is needed at client creation time — you can subscribe
     const msg = await client.getPubSubMessage();
 
     await client.close();
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    # Create a regular client — no subscription configuration needed
-    config = GlideClientConfiguration(
-        [NodeAddress("localhost", 6379)],
-    )
-    client = await GlideClient.create(config)
-
-    # --- Exact channel subscriptions ---
-
-    # Blocking: waits up to 5000ms for server confirmation
-    await client.subscribe({"news", "updates"}, timeout_ms=5000)
-
-    # Non-blocking (lazy): returns immediately, subscribes in background
-    await client.subscribe_lazy({"alerts"})
-
-    # --- Pattern subscriptions ---
-
-    # Blocking
-    await client.psubscribe({"chat*", "event*"}, timeout_ms=5000)
-
-    # Non-blocking (lazy)
-    await client.psubscribe_lazy({"log*"})
-
-    # --- Sharded subscriptions (cluster mode only) ---
-    # await cluster_client.ssubscribe({"shard-ch1"}, timeout_ms=5000)
-    # await cluster_client.ssubscribe_lazy({"shard-ch2"})
-
-    # Retrieve messages via polling
-    msg = await client.get_pubsub_message()
-
-    await client.close()
     ```
   </TabItem>
 
@@ -339,6 +339,37 @@ No special configuration is needed at client creation time — you can subscribe
 For GLIDE versions prior to 2.3, or when your subscriptions are known at startup, you can define them in the client configuration. These subscriptions are applied immediately when the client connects.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    # Define callback and context
+    def callback(msg: CoreCommands.PubSubMsg, ctx: Any):
+        print(f"Received {msg}, context {ctx}\n")
+    context = "example"
+
+    # Configure the client to invoke the callback for messages published
+    # to 'ch1' and 'ch2' and to channels matched by 'chat*' glob pattern.
+    subscription_config = GlideClientConfiguration.PubSubSubscriptions(
+        channels_and_patterns={
+            GlideClientConfiguration.PubSubChannelModes.Exact: {"ch1", "ch2"},
+            GlideClientConfiguration.PubSubChannelModes.Pattern: {"chat*"}
+        },
+        callback=callback,
+        context=context,
+    )
+
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+        pubsub_subscriptions=subscription_config
+    )
+
+    listening_client = await GlideClient.create(config)
+
+    # Do some work/wait - the callback will be invoked on incoming messages
+
+    await listening_client.close()    # Unsubscribe happens here
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // Define callback and context
@@ -396,37 +427,6 @@ For GLIDE versions prior to 2.3, or when your subscriptions are known at startup
     // Do some work/wait - the callback will be invoked on incoming messages
 
     listeningClient.close();    // Unsubscribe happens here
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    # Define callback and context
-    def callback(msg: CoreCommands.PubSubMsg, ctx: Any):
-        print(f"Received {msg}, context {ctx}\n")
-    context = "example"
-
-    # Configure the client to invoke the callback for messages published
-    # to 'ch1' and 'ch2' and to channels matched by 'chat*' glob pattern.
-    subscription_config = GlideClientConfiguration.PubSubSubscriptions(
-        channels_and_patterns={
-            GlideClientConfiguration.PubSubChannelModes.Exact: {"ch1", "ch2"},
-            GlideClientConfiguration.PubSubChannelModes.Pattern: {"chat*"}
-        },
-        callback=callback,
-        context=context,
-    )
-
-    config = GlideClientConfiguration(
-        [NodeAddress("localhost", 6379)],
-        pubsub_subscriptions=subscription_config
-    )
-
-    listening_client = await GlideClient.create(config)
-
-    # Do some work/wait - the callback will be invoked on incoming messages
-
-    await listening_client.close()    # Unsubscribe happens here
     ```
   </TabItem>
 
@@ -504,6 +504,38 @@ When a callback is configured, all incoming messages are sent to that callback. 
 To use callback-based delivery, provide a subscription configuration with a callback at client creation time. The callback fires for every incoming message — from both config-based and dynamic subscriptions.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    received = []
+
+    def callback(msg: CoreCommands.PubSubMsg, context: Any):
+        received.append(msg.message)
+        print(f"Received '{msg.message}' on '{msg.channel}'")
+
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+        pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
+            channels_and_patterns={},
+            callback=callback,
+            context=None,
+        ),
+    )
+    client = await GlideClient.create(config)
+
+    # Subscribe dynamically — messages are delivered to the callback
+    await client.subscribe({"news"}, timeout_ms=5000)
+
+    # Publish a message (from another client)
+    await publishing_client.publish("Hello!", "news")
+    await asyncio.sleep(0.5)
+
+    # Verify the callback received the message
+    assert "Hello!" in received
+
+    await client.close()
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     List<String> received = Collections.synchronizedList(new ArrayList<>());
@@ -562,38 +594,6 @@ To use callback-based delivery, provide a subscription configuration with a call
     console.assert(received.includes("Hello!"));
 
     client.close();
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    received = []
-
-    def callback(msg: CoreCommands.PubSubMsg, context: Any):
-        received.append(msg.message)
-        print(f"Received '{msg.message}' on '{msg.channel}'")
-
-    config = GlideClientConfiguration(
-        [NodeAddress("localhost", 6379)],
-        pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
-            channels_and_patterns={},
-            callback=callback,
-            context=None,
-        ),
-    )
-    client = await GlideClient.create(config)
-
-    # Subscribe dynamically — messages are delivered to the callback
-    await client.subscribe({"news"}, timeout_ms=5000)
-
-    # Publish a message (from another client)
-    await publishing_client.publish("Hello!", "news")
-    await asyncio.sleep(0.5)
-
-    # Verify the callback received the message
-    assert "Hello!" in received
-
-    await client.close()
     ```
   </TabItem>
 
@@ -685,6 +685,34 @@ If no callback is configured, messages are buffered in an unbounded queue. You r
 * **Non-blocking poll:** `tryGetPubSubMessage()` / `try_get_pubsub_message()` — returns the next message or `null`/`None` immediately.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    # Configure the client to receive messages published to 'ch1'
+    # and 'ch2' and to channels matched by 'chat*' glob pattern.
+    subscriptions_config = GlideClientConfiguration.PubSubSubscriptions(
+        channels_and_patterns={
+            GlideClientConfiguration.PubSubChannelModes.Exact: {"ch1", "ch2"},
+            GlideClientConfiguration.PubSubChannelModes.Pattern: {"chat*"},
+        },
+    )
+
+    config = GlideClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+        pubsub_subscriptions=subscriptions_config,
+    )
+
+    listening_client = await GlideClient.create(config)
+
+    # Non-blocking: returns None if no message is available
+    message = listening_client.try_get_pubsub_message()
+
+    # Async: waits for the next message
+    message = await listening_client.get_pubsub_message()
+
+    await listening_client.close()    # Unsubscribe happens here
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // Configure the client to receive messages published to 'ch1'
@@ -735,34 +763,6 @@ If no callback is configured, messages are buffered in an unbounded queue. You r
     const message = await listeningClient.getPubSubMessage();
 
     listeningClient.close();    // Unsubscribe happens here
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    # Configure the client to receive messages published to 'ch1'
-    # and 'ch2' and to channels matched by 'chat*' glob pattern.
-    subscriptions_config = GlideClientConfiguration.PubSubSubscriptions(
-        channels_and_patterns={
-            GlideClientConfiguration.PubSubChannelModes.Exact: {"ch1", "ch2"},
-            GlideClientConfiguration.PubSubChannelModes.Pattern: {"chat*"},
-        },
-    )
-
-    config = GlideClientConfiguration(
-        [NodeAddress("localhost", 6379)],
-        pubsub_subscriptions=subscriptions_config,
-    )
-
-    listening_client = await GlideClient.create(config)
-
-    # Non-blocking: returns None if no message is available
-    message = listening_client.try_get_pubsub_message()
-
-    # Async: waits for the next message
-    message = await listening_client.get_pubsub_message()
-
-    await listening_client.close()    # Unsubscribe happens here
     ```
   </TabItem>
 
@@ -873,6 +873,33 @@ Prior to GLIDE 2.3, runtime unsubscribing is not available. Subscriptions are re
 :::
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    # Unsubscribe from specific exact channels (blocking)
+    await client.unsubscribe({"news"}, timeout_ms=5000)
+
+    # Unsubscribe from specific exact channels (lazy)
+    await client.unsubscribe_lazy({"alerts"})
+
+    # Unsubscribe from all exact channels
+    await client.unsubscribe(ALL_CHANNELS, timeout_ms=5000)
+
+    # Unsubscribe from specific patterns (blocking)
+    await client.punsubscribe({"chat*"}, timeout_ms=5000)
+
+    # Unsubscribe from specific patterns (lazy)
+    await client.punsubscribe_lazy({"log*"})
+
+    # Unsubscribe from all patterns
+    await client.punsubscribe(ALL_PATTERNS, timeout_ms=5000)
+
+    # Sharded unsubscribe (cluster mode only)
+    # await cluster_client.sunsubscribe({"shard-ch1"}, timeout_ms=5000)
+    # await cluster_client.sunsubscribe_lazy({"shard-ch2"})
+    # await cluster_client.sunsubscribe(ALL_SHARDED_CHANNELS, timeout_ms=5000)
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     // Unsubscribe from specific exact channels (blocking)
@@ -924,33 +951,6 @@ Prior to GLIDE 2.3, runtime unsubscribing is not available. Subscriptions are re
     // await clusterClient.sunsubscribe(new Set(["shard-ch1"]), 5000);
     // await clusterClient.sunsubscribeLazy(new Set(["shard-ch2"]));
     // await clusterClient.sunsubscribe(ALL_SHARDED_CHANNELS, 5000);
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    # Unsubscribe from specific exact channels (blocking)
-    await client.unsubscribe({"news"}, timeout_ms=5000)
-
-    # Unsubscribe from specific exact channels (lazy)
-    await client.unsubscribe_lazy({"alerts"})
-
-    # Unsubscribe from all exact channels
-    await client.unsubscribe(ALL_CHANNELS, timeout_ms=5000)
-
-    # Unsubscribe from specific patterns (blocking)
-    await client.punsubscribe({"chat*"}, timeout_ms=5000)
-
-    # Unsubscribe from specific patterns (lazy)
-    await client.punsubscribe_lazy({"log*"})
-
-    # Unsubscribe from all patterns
-    await client.punsubscribe(ALL_PATTERNS, timeout_ms=5000)
-
-    # Sharded unsubscribe (cluster mode only)
-    # await cluster_client.sunsubscribe({"shard-ch1"}, timeout_ms=5000)
-    # await cluster_client.sunsubscribe_lazy({"shard-ch2"})
-    # await cluster_client.sunsubscribe(ALL_SHARDED_CHANNELS, timeout_ms=5000)
     ```
   </TabItem>
 
@@ -1046,6 +1046,14 @@ Prior to GLIDE 2.3, runtime unsubscribing is not available. Subscriptions are re
 Use `get_subscriptions()` to inspect the current subscription state. It returns both the **desired** subscriptions (what you've requested) and the **actual** subscriptions (what the server has confirmed). This is useful for verifying that lazy subscriptions have been fully applied.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```py
+    state = await client.get_subscriptions()
+    print(f"Desired: {state.desired_subscriptions}")
+    print(f"Actual: {state.actual_subscriptions}")
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     PubSubState state = client.getSubscriptions().get();
@@ -1059,14 +1067,6 @@ Use `get_subscriptions()` to inspect the current subscription state. It returns 
     const state = await client.getSubscriptions();
     console.log("Desired:", state.desiredSubscriptions);
     console.log("Actual:", state.actualSubscriptions);
-    ```
-  </TabItem>
-
-  <TabItem label="Python">
-    ```py
-    state = await client.get_subscriptions()
-    print(f"Desired: {state.desired_subscriptions}")
-    print(f"Actual: {state.actual_subscriptions}")
     ```
   </TabItem>
 

--- a/src/content/docs/how-to/scan-cluster.mdx
+++ b/src/content/docs/how-to/scan-cluster.mdx
@@ -78,21 +78,6 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
-    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
-
-    await foreach (var key in clusterClient.ScanAsync())
-    {
-        Console.WriteLine($"Key: {key}");
-    }
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     $cursor = new ClusterScanCursor();
@@ -110,6 +95,21 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
         if ($cursor->isFinished()) {
             break;
         }
+    }
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var clusterConfig = new ClusterClientConfigurationBuilder().Build();
+    await using var clusterClient = await GlideClusterClient.CreateClient(clusterConfig);
+
+    await foreach (var key in clusterClient.ScanAsync())
+    {
+        Console.WriteLine($"Key: {key}");
     }
     ```
   </TabItem>
@@ -198,6 +198,29 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client->mset(['my_key1' => 'value1', 'my_key2' => 'value2', 'not_my_key' => 'value3', 'something_else' => 'value4']);
+
+    $cursor = new ClusterScanCursor();
+    $matchingKeys = [];
+
+    while (true) {
+        $keys = $client->scan($cursor, '*key*');
+        if ($keys) {
+            $matchingKeys = array_merge($matchingKeys, $keys);
+        }
+        
+        $cursor = new ClusterScanCursor($cursor->getNextCursor());
+        
+        if ($cursor->isFinished()) {
+            break;
+        }
+    }
+    // Returns matching keys such as ['my_key1', 'my_key2', 'not_my_key']
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -222,29 +245,6 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     }
 
     // Returns matching keys such as ["my_key1", "my_key2", "not_my_key"]
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client->mset(['my_key1' => 'value1', 'my_key2' => 'value2', 'not_my_key' => 'value3', 'something_else' => 'value4']);
-
-    $cursor = new ClusterScanCursor();
-    $matchingKeys = [];
-
-    while (true) {
-        $keys = $client->scan($cursor, '*key*');
-        if ($keys) {
-            $matchingKeys = array_merge($matchingKeys, $keys);
-        }
-        
-        $cursor = new ClusterScanCursor($cursor->getNextCursor());
-        
-        if ($cursor->isFinished()) {
-            break;
-        }
-    }
-    // Returns matching keys such as ['my_key1', 'my_key2', 'not_my_key']
     ```
   </TabItem>
 </Tabs>
@@ -324,6 +324,16 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client->mset(['my_key1' => 'value1', 'my_key2' => 'value2', 'not_my_key' => 'value3', 'something_else' => 'value4']);
+
+    $cursor = new ClusterScanCursor();
+    $keys = $client->scan($cursor, null, 1); // 1 is the count parameter
+    // Returns around `count` keys: ['my_key1']
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -348,16 +358,6 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     }
 
     // Returns around `count` keys per iteration
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client->mset(['my_key1' => 'value1', 'my_key2' => 'value2', 'not_my_key' => 'value3', 'something_else' => 'value4']);
-
-    $cursor = new ClusterScanCursor();
-    $keys = $client->scan($cursor, null, 1); // 1 is the count parameter
-    // Returns around `count` keys: ['my_key1']
     ```
   </TabItem>
 </Tabs>
@@ -448,6 +448,30 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client->mset(['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3']);
+    $client->sadd('this_is_a_set', 'value4');
+
+    $cursor = new ClusterScanCursor();
+    $allKeys = [];
+
+    while (true) {
+        $keys = $client->scan($cursor, null, 0, 'string');
+        if ($keys) {
+            $allKeys = array_merge($allKeys, $keys);
+        }
+        
+        $cursor = new ClusterScanCursor($cursor->getNextCursor());
+        
+        if ($cursor->isFinished()) {
+            break;
+        }
+    }
+    // Output: ['key1', 'key2', 'key3']
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -472,30 +496,6 @@ For a detailed explanation of Cluster Scan, see our [article](/concepts/client-f
     }
 
     // keys: ["key1", "key2", "key3"]
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client->mset(['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3']);
-    $client->sadd('this_is_a_set', 'value4');
-
-    $cursor = new ClusterScanCursor();
-    $allKeys = [];
-
-    while (true) {
-        $keys = $client->scan($cursor, null, 0, 'string');
-        if ($keys) {
-            $allKeys = array_merge($allKeys, $keys);
-        }
-        
-        $cursor = new ClusterScanCursor($cursor->getNextCursor());
-        
-        if ($cursor->isFinished()) {
-            break;
-        }
-    }
-    // Output: ['key1', 'key2', 'key3']
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/security/dynamic-authentication.mdx
+++ b/src/content/docs/how-to/security/dynamic-authentication.mdx
@@ -17,6 +17,44 @@ The dynamic password update functionality does not rotate the password on the se
 Below are examples demonstrating how to utilize the dynamic password update feature in different programming languages using GLIDE.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    import asyncio
+    from glide import GlideClusterClientConfiguration, NodeAddress, GlideClusterClient
+
+    async def main():
+        # Define your server credentials
+        credentials = ServerCredentials(
+            username='your-username',
+            password='your-password-or-token'
+        )
+        # Define the list of node addresses
+        addresses = [
+            NodeAddress("my-instance.valkey.us-central1.gcp.cloud", 6379),
+        ]
+        # Create a configuration for the GlideClusterClient
+        config = GlideClusterClientConfiguration(
+            addresses=addresses,
+            credentials=credentials,
+            request_timeout=250,
+            client_name='my-client'
+        )
+
+        # Create the GlideClusterClient instance
+        client = await GlideClusterClient.create_client(config)
+
+        # Update password dynamically
+        await client.update_connection_password('your-new-password')
+        # To perform immediate re-authentication, set the second parameter to true
+        await client.update_connection_password('your-new-password', True)
+        # Resetting password by passing None
+        await client.update_connection_password(None) # Note: This will clear the password from the connection configuration.
+
+
+    asyncio.run(main())
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     import com.valkey.glide.GlideClusterClient;
@@ -103,75 +141,9 @@ Below are examples demonstrating how to utilize the dynamic password update feat
     ```
   </TabItem>
 
-  <TabItem label="Python">
-    ```python
-    import asyncio
-    from glide import GlideClusterClientConfiguration, NodeAddress, GlideClusterClient
-
-    async def main():
-        # Define your server credentials
-        credentials = ServerCredentials(
-            username='your-username',
-            password='your-password-or-token'
-        )
-        # Define the list of node addresses
-        addresses = [
-            NodeAddress("my-instance.valkey.us-central1.gcp.cloud", 6379),
-        ]
-        # Create a configuration for the GlideClusterClient
-        config = GlideClusterClientConfiguration(
-            addresses=addresses,
-            credentials=credentials,
-            request_timeout=250,
-            client_name='my-client'
-        )
-
-        # Create the GlideClusterClient instance
-        client = await GlideClusterClient.create_client(config)
-
-        # Update password dynamically
-        await client.update_connection_password('your-new-password')
-        # To perform immediate re-authentication, set the second parameter to true
-        await client.update_connection_password('your-new-password', True)
-        # Resetting password by passing None
-        await client.update_connection_password(None) # Note: This will clear the password from the connection configuration.
-
-
-    asyncio.run(main())
-    ```
-  </TabItem>
-
   <TabItem label="Go">
     ```go
     // TODO: Add Example
-    ```
-  </TabItem>
-
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    var config = new ClusterClientConfigurationBuilder()
-        .WithAddress("localhost", 6379)
-        .WithAuthentication("your-username", "your-password-or-token")
-        .WithRequestTimeout(TimeSpan.FromMilliseconds(5000))
-        .WithClientName("my-client")
-        .Build();
-
-    await using var client = await GlideClusterClient.CreateClient(config);
-
-    // Update password with lazy re-authentication.
-    await client.UpdateConnectionPasswordAsync("your-new-password");
-
-    // Update password with immediate re-authentication.
-    await client.UpdateConnectionPasswordAsync("your-new-password", immediateAuth: true);
-
-    // Clear password with lazy re-authentication.
-    await client.ClearConnectionPasswordAsync();
-
-    // Clear password with immediate re-authentication.
-    await client.ClearConnectionPasswordAsync(immediateAuth: true);
     ```
   </TabItem>
 
@@ -207,6 +179,34 @@ Below are examples demonstrating how to utilize the dynamic password update feat
     $client->clearConnectionPassword(); // Note: This will clear the password from the connection configuration.
     ```
   </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    var config = new ClusterClientConfigurationBuilder()
+        .WithAddress("localhost", 6379)
+        .WithAuthentication("your-username", "your-password-or-token")
+        .WithRequestTimeout(TimeSpan.FromMilliseconds(5000))
+        .WithClientName("my-client")
+        .Build();
+
+    await using var client = await GlideClusterClient.CreateClient(config);
+
+    // Update password with lazy re-authentication.
+    await client.UpdateConnectionPasswordAsync("your-new-password");
+
+    // Update password with immediate re-authentication.
+    await client.UpdateConnectionPasswordAsync("your-new-password", immediateAuth: true);
+
+    // Clear password with lazy re-authentication.
+    await client.ClearConnectionPasswordAsync();
+
+    // Clear password with immediate re-authentication.
+    await client.ClearConnectionPasswordAsync(immediateAuth: true);
+    ```
+  </TabItem>
 </Tabs>
 
 :::caution
@@ -226,6 +226,14 @@ When dynamically switching to a new credential, ensure that it has enough permis
 In scenarios where a username is not required (e.g., IAM authentication), you can omit it or set it to `null`.
 
 <Tabs syncKey="progLangInExamples">
+  <TabItem label="Python">
+    ```python
+    credentials = ServerCredentials(
+        password='your-password-or-token'
+    )
+    ```
+  </TabItem>
+
   <TabItem label="Java">
     ```java
     ServerCredentials credentials = ServerCredentials.builder()
@@ -242,17 +250,17 @@ In scenarios where a username is not required (e.g., IAM authentication), you ca
     ```
   </TabItem>
 
-  <TabItem label="Python">
-    ```python
-    credentials = ServerCredentials(
-        password='your-password-or-token'
-    )
-    ```
-  </TabItem>
-
   <TabItem label="Go">
     ```go
     // TODO: Add Example
+    ```
+  </TabItem>
+
+  <TabItem label="PHP">
+    ```php
+    $credentials = [
+        'password' => 'your-password-or-token'
+    ];
     ```
   </TabItem>
 
@@ -264,14 +272,6 @@ In scenarios where a username is not required (e.g., IAM authentication), you ca
         .WithAddress("address.example.com", 6379)
         .WithAuthentication("your-password-or-token")
         .Build();
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $credentials = [
-        'password' => 'your-password-or-token'
-    ];
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/security/iam-integration.mdx
+++ b/src/content/docs/how-to/security/iam-integration.mdx
@@ -34,31 +34,6 @@ For GLIDE versions below 2.2, see the [guide](/how-to/security/iam-integration-u
 ## Examples
 
 <Tabs syncKey="progLangInExamples">
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-    using static Valkey.Glide.ConnectionConfiguration;
-
-    // Configure IAM authentication
-    // Automatically regenerates the token every 5 mins (default: 300 seconds)
-    var iamConfig = new IamAuthConfig(
-        clusterName: "clustername",
-        serviceType: ServiceType.ElastiCache, // or ServiceType.MemoryDB
-        region: "us-east-1"
-        // refreshIntervalSeconds: 100 // Optional, default is 300 seconds
-    );
-
-    var credentials = new ServerCredentials("username", iamConfig);
-
-    var config = new ClusterClientConfigurationBuilder()
-        .WithAddress("endpoint.example.com", 6379)
-        .WithCredentials(credentials)
-        .Build();
-
-    await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
   <TabItem label="Python">
     ```python
     from glide import (
@@ -212,6 +187,31 @@ For GLIDE versions below 2.2, see the [guide](/how-to/security/iam-integration-u
 
     $client->close();
     ...
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+    using static Valkey.Glide.ConnectionConfiguration;
+
+    // Configure IAM authentication
+    // Automatically regenerates the token every 5 mins (default: 300 seconds)
+    var iamConfig = new IamAuthConfig(
+        clusterName: "clustername",
+        serviceType: ServiceType.ElastiCache, // or ServiceType.MemoryDB
+        region: "us-east-1"
+        // refreshIntervalSeconds: 100 // Optional, default is 300 seconds
+    );
+
+    var credentials = new ServerCredentials("username", iamConfig);
+
+    var config = new ClusterClientConfigurationBuilder()
+        .WithAddress("endpoint.example.com", 6379)
+        .WithCredentials(credentials)
+        .Build();
+
+    await using var client = await GlideClusterClient.CreateClient(config);
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/how-to/security/tls.mdx
+++ b/src/content/docs/how-to/security/tls.mdx
@@ -84,6 +84,19 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $addresses = [
+        ['host' => 'address.example.com', 'port' => 6379]
+    ];
+
+    $client = new ValkeyGlideCluster(
+        addresses: $addresses,
+        use_tls: true
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -95,19 +108,6 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $addresses = [
-        ['host' => 'address.example.com', 'port' => 6379]
-    ];
-
-    $client = new ValkeyGlideCluster(
-        addresses: $addresses,
-        use_tls: true
-    );
     ```
   </TabItem>
 
@@ -197,6 +197,19 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $addresses = [
+        ['host' => 'primary.example.com', 'port' => 6379],
+        ['host' => 'replica1.example.com', 'port' => 6379],
+        ['host' => 'replica2.example.com', 'port' => 6379]
+    ];
+
+    $client = new ValkeyGlide();
+    $client->connect(addresses: $addresses, use_tls: true);
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -210,19 +223,6 @@ Enabling TLS is as simple as setting `use_tls=True` in your configuration. The c
         .Build();
 
     await using var client = await GlideClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $addresses = [
-        ['host' => 'primary.example.com', 'port' => 6379],
-        ['host' => 'replica1.example.com', 'port' => 6379],
-        ['host' => 'replica2.example.com', 'port' => 6379]
-    ];
-
-    $client = new ValkeyGlide();
-    $client->connect(addresses: $addresses, use_tls: true);
     ```
   </TabItem>
 
@@ -297,6 +297,16 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
     :::
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client = new ValkeyGlideCluster(
+        addresses: [['host' => 'address.example.com', 'port' => 6379]],
+        use_tls: true,
+        advanced_config: ['tls_config' => ['use_insecure_tls' => true]]
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -309,16 +319,6 @@ Insecure TLS mode bypasses certificate verification. This is useful when connect
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client = new ValkeyGlideCluster(
-        addresses: [['host' => 'address.example.com', 'port' => 6379]],
-        use_tls: true,
-        advanced_config: ['tls_config' => ['use_insecure_tls' => true]]
-    );
     ```
   </TabItem>
 </Tabs>
@@ -456,6 +456,39 @@ You can provide custom root certificates for TLS connections. This is useful whe
     :::
   </TabItem>
 
+  <TabItem label="PHP">
+    #### Example - Connecting with Custom Root Certificate
+
+    ```php
+    // Read certificate file
+    $rootCert = file_get_contents('/path/to/ca-cert.pem');
+
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'address.example.com', 'port' => 6379]],
+        use_tls: true,
+        advanced_config: ['tls_config' => ['root_certs' => $rootCert]]
+    );
+    ```
+
+    #### Example - Using Certificate as String
+
+    ```php
+    $certData = <<<'CERT'
+    -----BEGIN CERTIFICATE-----
+    MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKmzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+    ...
+    -----END CERTIFICATE-----
+    CERT;
+
+    $client = new ValkeyGlideCluster(
+        addresses: [['host' => 'address.example.com', 'port' => 6379]],
+        use_tls: true,
+        advanced_config: ['tls_config' => ['root_certs' => $certData]]
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     **Certificate Behavior:**
 
@@ -516,39 +549,6 @@ You can provide custom root certificates for TLS connections. This is useful whe
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    #### Example - Connecting with Custom Root Certificate
-
-    ```php
-    // Read certificate file
-    $rootCert = file_get_contents('/path/to/ca-cert.pem');
-
-    $client = new ValkeyGlide();
-    $client->connect(
-        addresses: [['host' => 'address.example.com', 'port' => 6379]],
-        use_tls: true,
-        advanced_config: ['tls_config' => ['root_certs' => $rootCert]]
-    );
-    ```
-
-    #### Example - Using Certificate as String
-
-    ```php
-    $certData = <<<'CERT'
-    -----BEGIN CERTIFICATE-----
-    MIIDXTCCAkWgAwIBAgIJAKL0UG+mRKmzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-    ...
-    -----END CERTIFICATE-----
-    CERT;
-
-    $client = new ValkeyGlideCluster(
-        addresses: [['host' => 'address.example.com', 'port' => 6379]],
-        use_tls: true,
-        advanced_config: ['tls_config' => ['root_certs' => $certData]]
-    );
     ```
   </TabItem>
 
@@ -714,15 +714,15 @@ MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7...
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
-    :::
-  </TabItem>
-
   <TabItem label="PHP">
     :::note[Coming soon]
     Mutual TLS configuration documentation for PHP is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note[Coming soon]
+    Mutual TLS configuration documentation for C# is coming soon.
     :::
   </TabItem>
 </Tabs>
@@ -811,15 +811,15 @@ Use `WithMutualTLSFromFiles(certPath, keyPath)` (Go) or `useMutualTlsWithReload(
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
-    :::
-  </TabItem>
-
   <TabItem label="PHP">
     :::note[Coming soon]
     Mutual TLS configuration documentation for PHP is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note[Coming soon]
+    Mutual TLS configuration documentation for C# is coming soon.
     :::
   </TabItem>
 </Tabs>
@@ -910,15 +910,15 @@ Pass a positive interval in seconds to override the core default. In Java, use `
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
-    :::
-  </TabItem>
-
   <TabItem label="PHP">
     :::note[Coming soon]
     Mutual TLS configuration documentation for PHP is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note[Coming soon]
+    Mutual TLS configuration documentation for C# is coming soon.
     :::
   </TabItem>
 </Tabs>
@@ -1015,15 +1015,15 @@ Helpers exist to read PEM bytes from disk and feed the in-memory mode.
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    :::note[Coming soon]
-    Mutual TLS configuration documentation for C# is coming soon.
-    :::
-  </TabItem>
-
   <TabItem label="PHP">
     :::note[Coming soon]
     Mutual TLS configuration documentation for PHP is coming soon.
+    :::
+  </TabItem>
+
+  <TabItem label="C#">
+    :::note[Coming soon]
+    Mutual TLS configuration documentation for C# is coming soon.
     :::
   </TabItem>
 </Tabs>

--- a/src/content/docs/reference/connection-options.mdx
+++ b/src/content/docs/reference/connection-options.mdx
@@ -41,19 +41,6 @@ The following are the configuration references for each Glide clients:
     ```
   </TabItem>
 
-  <TabItem label="Node">
-    ```typescript
-    import { GlideClientOptions } from "@valkey/valkey-glide";
-
-    const config: GlideClientOptions = {
-        addresses: [{ host: "localhost", port: 6379 }],
-        useTLS: false,
-        requestTimeout: 1000,
-        clientName: "node_app"
-    };
-    ```
-  </TabItem>
-
   <TabItem label="Java">
     ```java
     import glide.api.models.configuration.GlideClientConfiguration;
@@ -65,6 +52,19 @@ The following are the configuration references for each Glide clients:
         .requestTimeout(1000)
         .clientName("java_app")
         .build();
+    ```
+  </TabItem>
+
+  <TabItem label="Node">
+    ```typescript
+    import { GlideClientOptions } from "@valkey/valkey-glide";
+
+    const config: GlideClientOptions = {
+        addresses: [{ host: "localhost", port: 6379 }],
+        useTLS: false,
+        requestTimeout: 1000,
+        clientName: "node_app"
+    };
     ```
   </TabItem>
 

--- a/src/content/docs/reference/scripting-reference.mdx
+++ b/src/content/docs/reference/scripting-reference.mdx
@@ -295,6 +295,20 @@ end
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Read script from file
+    $rateLimit = file_get_contents('rate_limit.lua');
+
+    // Usage
+    $result = $client->eval(
+        $rateLimit,
+        ['rate_limit:user:123', '10', '60'],  // 10 requests per 60 seconds
+        1  // num_keys
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -313,20 +327,6 @@ end
         new ScriptOptions()
             .WithKeys("rate_limit:user:123")
             .WithArgs("10", "60")); // 10 requests per 60 seconds
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Read script from file
-    $rateLimit = file_get_contents('rate_limit.lua');
-
-    // Usage
-    $result = $client->eval(
-        $rateLimit,
-        ['rate_limit:user:123', '10', '60'],  // 10 requests per 60 seconds
-        1  // num_keys
-    );
     ```
   </TabItem>
 
@@ -513,6 +513,34 @@ end
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Read scripts from files
+    $acquireLock = file_get_contents('acquire_lock.lua');
+    $releaseLock = file_get_contents('release_lock.lua');
+
+    // Acquire lock
+    $lockAcquired = $client->eval(
+        $acquireLock,
+        ['lock:resource:123', 'unique_token', '30'],  // 30 second expiration
+        1  // num_keys
+    );
+
+    if ($lockAcquired) {
+        try {
+            // Do work while holding lock
+        } finally {
+            // Release lock
+            $client->eval(
+                $releaseLock,
+                ['lock:resource:123', 'unique_token'],
+                1  // num_keys
+            );
+        }
+    }
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -549,34 +577,6 @@ end
                 new ScriptOptions()
                     .WithKeys("lock:resource:123")
                     .WithArgs("unique_token"));
-        }
-    }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Read scripts from files
-    $acquireLock = file_get_contents('acquire_lock.lua');
-    $releaseLock = file_get_contents('release_lock.lua');
-
-    // Acquire lock
-    $lockAcquired = $client->eval(
-        $acquireLock,
-        ['lock:resource:123', 'unique_token', '30'],  // 30 second expiration
-        1  // num_keys
-    );
-
-    if ($lockAcquired) {
-        try {
-            // Do work while holding lock
-        } finally {
-            // Release lock
-            $client->eval(
-                $releaseLock,
-                ['lock:resource:123', 'unique_token'],
-                1  // num_keys
-            );
         }
     }
     ```
@@ -707,6 +707,20 @@ end
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Read script from file
+    $conditionalUpdate = file_get_contents('conditional_update.lua');
+
+    // Update only if current value matches expected
+    $updated = $client->eval(
+        $conditionalUpdate,
+        ['user:123:status', 'pending', 'active'],  // Change from "pending" to "active"
+        1  // num_keys
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -725,20 +739,6 @@ end
         new ScriptOptions()
             .WithKeys("user:123:status")
             .WithArgs("pending", "active")); // Change from "pending" to "active"
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Read script from file
-    $conditionalUpdate = file_get_contents('conditional_update.lua');
-
-    // Update only if current value matches expected
-    $updated = $client->eval(
-        $conditionalUpdate,
-        ['user:123:status', 'pending', 'active'],  // Change from "pending" to "active"
-        1  // num_keys
-    );
     ```
   </TabItem>
 
@@ -863,6 +863,28 @@ end
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Handle script execution errors
+    $script = "return redis.call('INCR', 'not_a_number')";
+
+    try {
+        $result = $client->eval($script, ['not_a_number'], 0);
+    } catch (ValkeyGlideException $e) {
+        $message = $e->getMessage();
+        if (str_contains($message, 'WRONGTYPE') || str_contains($message, 'not an integer')) {
+            echo "Type error in script\n";
+        } elseif (str_contains(strtolower($message), 'syntax error')) {
+            echo "Lua syntax error in script\n";
+        } elseif (str_contains(strtolower($message), 'unknown command')) {
+            echo "Invalid Redis command in script\n";
+        } else {
+            echo "Script error: $message\n";
+        }
+    }
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -890,28 +912,6 @@ end
             Console.WriteLine("Invalid Redis command in script");
         else
             Console.WriteLine($"Script error: {message}");
-    }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Handle script execution errors
-    $script = "return redis.call('INCR', 'not_a_number')";
-
-    try {
-        $result = $client->eval($script, ['not_a_number'], 0);
-    } catch (ValkeyGlideException $e) {
-        $message = $e->getMessage();
-        if (str_contains($message, 'WRONGTYPE') || str_contains($message, 'not an integer')) {
-            echo "Type error in script\n";
-        } elseif (str_contains(strtolower($message), 'syntax error')) {
-            echo "Lua syntax error in script\n";
-        } elseif (str_contains(strtolower($message), 'unknown command')) {
-            echo "Invalid Redis command in script\n";
-        } else {
-            echo "Script error: $message\n";
-        }
     }
     ```
   </TabItem>
@@ -1107,6 +1107,43 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    **Requirements:** PHP 8.1+
+
+    ```php
+    // Configure client timeout for long-running scripts
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        request_timeout: 30000  // 30 seconds for long scripts (default is 250ms)
+    );
+
+    // Handle long-running scripts
+    $longScript = <<<'LUA'
+    local start = redis.call('TIME')[1]
+    while redis.call('TIME')[1] - start < 25 do
+        redis.call('GET', 'dummy_key')  -- Read-only operation
+    end
+    return 'Done'
+    LUA;
+
+    try {
+        $result = $client->eval($longScript, [], 0);
+        echo "Script completed: $result\n";
+    } catch (ValkeyGlideException $e) {
+        $message = $e->getMessage();
+        if (str_contains(strtolower($message), 'timeout')) {
+            echo "Client timeout - script may still be running on server!\n";
+            echo "Consider increasing request_timeout in client configuration\n";
+        } elseif (str_contains($message, 'Script killed')) {
+            echo "Script was killed by server (only possible for read-only scripts)\n";
+        } else {
+            echo "Script error: $message\n";
+        }
+    }
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1145,43 +1182,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
             Console.WriteLine("Script was killed by server (only possible for read-only scripts)");
         else
             Console.WriteLine($"Script error: {message}");
-    }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    **Requirements:** PHP 8.1+
-
-    ```php
-    // Configure client timeout for long-running scripts
-    $client = new ValkeyGlide();
-    $client->connect(
-        addresses: [['host' => 'localhost', 'port' => 6379]],
-        request_timeout: 30000  // 30 seconds for long scripts (default is 250ms)
-    );
-
-    // Handle long-running scripts
-    $longScript = <<<'LUA'
-    local start = redis.call('TIME')[1]
-    while redis.call('TIME')[1] - start < 25 do
-        redis.call('GET', 'dummy_key')  -- Read-only operation
-    end
-    return 'Done'
-    LUA;
-
-    try {
-        $result = $client->eval($longScript, [], 0);
-        echo "Script completed: $result\n";
-    } catch (ValkeyGlideException $e) {
-        $message = $e->getMessage();
-        if (str_contains(strtolower($message), 'timeout')) {
-            echo "Client timeout - script may still be running on server!\n";
-            echo "Consider increasing request_timeout in client configuration\n";
-        } elseif (str_contains($message, 'Script killed')) {
-            echo "Script was killed by server (only possible for read-only scripts)\n";
-        } else {
-            echo "Script error: $message\n";
-        }
     }
     ```
   </TabItem>
@@ -1302,6 +1302,24 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Handle cluster routing errors
+    try {
+        $result = $clusterClient->eval(
+            $script,
+            ['key1', 'key2'],  // Might be in different slots
+            2  // num_keys
+        );
+    } catch (ValkeyGlideException $e) {
+        if (str_contains($e->getMessage(), 'CROSSSLOT')) {
+            echo "Keys are in different slots\n";
+            // Use hash tags or route explicitly
+        }
+    }
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1322,24 +1340,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     {
         Console.WriteLine("Keys are in different slots");
         // Use hash tags or route explicitly
-    }
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Handle cluster routing errors
-    try {
-        $result = $clusterClient->eval(
-            $script,
-            ['key1', 'key2'],  // Might be in different slots
-            2  // num_keys
-        );
-    } catch (ValkeyGlideException $e) {
-        if (str_contains($e->getMessage(), 'CROSSSLOT')) {
-            echo "Keys are in different slots\n";
-            // Use hash tags or route explicitly
-        }
     }
     ```
   </TabItem>
@@ -1484,6 +1484,31 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Good: Conditional update with multiple data structures
+    $conditionalUpdate = <<<'LUA'
+    local current = redis.call('GET', KEYS[1])
+    local threshold = tonumber(ARGV[2])
+
+    if current and tonumber(current) >= threshold then
+        redis.call('SET', KEYS[1], ARGV[1])
+        redis.call('LPUSH', KEYS[2], ARGV[1])
+        redis.call('EXPIRE', KEYS[2], ARGV[3])
+        return 1
+    else
+        return 0
+    end
+    LUA;
+
+    $result = $client->eval(
+        $conditionalUpdate,
+        ['user:score', 'user:history', '100', '50', '86400'],  // new score, threshold, expire in 1 day
+        2  // num_keys
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1512,31 +1537,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
         new ScriptOptions()
             .WithKeys("user:score", "user:history")
             .WithArgs("100", "50", "86400")); // new score, threshold, expire in 1 day
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Good: Conditional update with multiple data structures
-    $conditionalUpdate = <<<'LUA'
-    local current = redis.call('GET', KEYS[1])
-    local threshold = tonumber(ARGV[2])
-
-    if current and tonumber(current) >= threshold then
-        redis.call('SET', KEYS[1], ARGV[1])
-        redis.call('LPUSH', KEYS[2], ARGV[1])
-        redis.call('EXPIRE', KEYS[2], ARGV[3])
-        return 1
-    else
-        return 0
-    end
-    LUA;
-
-    $result = $client->eval(
-        $conditionalUpdate,
-        ['user:score', 'user:history', '100', '50', '86400'],  // new score, threshold, expire in 1 day
-        2  // num_keys
-    );
     ```
   </TabItem>
 
@@ -1635,6 +1635,20 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Good: Proper nil handling
+    $safeScript = <<<'LUA'
+    local val = redis.call('GET', KEYS[1])
+    if val then
+        return val
+    else
+        return 'default_value'
+    end
+    LUA;
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1648,20 +1662,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
             return 'default_value'
         end
     ");
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Good: Proper nil handling
-    $safeScript = <<<'LUA'
-    local val = redis.call('GET', KEYS[1])
-    if val then
-        return val
-    else
-        return 'default_value'
-    end
-    LUA;
     ```
   </TabItem>
 
@@ -1733,6 +1733,16 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Good: Return appropriate types
+    $typedScript = <<<'LUA'
+    local value = redis.call('GET', KEYS[1])
+    return tonumber(value) or 0  -- Ensure numeric return, default to 0 if nil
+    LUA;
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1742,16 +1752,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
         local value = redis.call('GET', KEYS[1])
         return tonumber(value) or 0  -- Ensure numeric return, default to 0 if nil
     ");
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Good: Return appropriate types
-    $typedScript = <<<'LUA'
-    local value = redis.call('GET', KEYS[1])
-    return tonumber(value) or 0  -- Ensure numeric return, default to 0 if nil
-    LUA;
     ```
   </TabItem>
 
@@ -1857,6 +1857,24 @@ When a client timeout occurs, the client stops waiting for a response, but the s
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    // Good: Use hash tags for related keys
+    $clusterScript = <<<'LUA'
+    redis.call('SET', KEYS[1], ARGV[1])
+    redis.call('SET', KEYS[2], ARGV[2])
+    return 'OK'
+    LUA;
+
+    // Execute with hash tags
+    $clusterClient->eval(
+        $clusterScript,
+        ['user:{123}:name', 'user:{123}:email', 'John', 'john@example.com'],
+        2  // num_keys
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -1878,24 +1896,6 @@ When a client timeout occurs, the client stops waiting for a response, but the s
         new ScriptOptions()
             .WithKeys("user:{123}:name", "user:{123}:email")
             .WithArgs("John", "john@example.com"));
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    // Good: Use hash tags for related keys
-    $clusterScript = <<<'LUA'
-    redis.call('SET', KEYS[1], ARGV[1])
-    redis.call('SET', KEYS[2], ARGV[2])
-    return 'OK'
-    LUA;
-
-    // Execute with hash tags
-    $clusterClient->eval(
-        $clusterScript,
-        ['user:{123}:name', 'user:{123}:email', 'John', 'john@example.com'],
-        2  // num_keys
-    );
     ```
   </TabItem>
 

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -52,19 +52,19 @@ To enable logging, you will need to set the logger from within your application.
     ```
   </TabItem>
 
-  <TabItem label="C#">
-    ```csharp
-    using Valkey.Glide;
-
-    Logger.SetLoggerConfig(Level.Debug);
-    ```
-  </TabItem>
-
   <TabItem label="PHP">
     ```php
     use Glide\Logger;
 
     Logger::setLoggerConfig(Logger::LEVEL_DEBUG);
+    ```
+  </TabItem>
+
+  <TabItem label="C#">
+    ```csharp
+    using Valkey.Glide;
+
+    Logger.SetLoggerConfig(Level.Debug);
     ```
   </TabItem>
 </Tabs>
@@ -165,6 +165,20 @@ To fix this, increase the **connection timeout** which is separate from the **re
     ```
   </TabItem>
 
+  <TabItem label="PHP">
+    ```php
+    $client = new ValkeyGlide();
+    $client->connect(
+        addresses: [['host' => 'localhost', 'port' => 6379]],
+        request_timeout: 5000,  // Request timeout in milliseconds
+        advanced_config: [
+            'connection_timeout' => 10000,  // Connection timeout in milliseconds
+            'socket_timeout' => 5000  // Socket read/write timeout in milliseconds
+        ]
+    );
+    ```
+  </TabItem>
+
   <TabItem label="C#">
     ```csharp
     using Valkey.Glide;
@@ -177,20 +191,6 @@ To fix this, increase the **connection timeout** which is separate from the **re
         .Build();
 
     await using var client = await GlideClusterClient.CreateClient(config);
-    ```
-  </TabItem>
-
-  <TabItem label="PHP">
-    ```php
-    $client = new ValkeyGlide();
-    $client->connect(
-        addresses: [['host' => 'localhost', 'port' => 6379]],
-        request_timeout: 5000,  // Request timeout in milliseconds
-        advanced_config: [
-            'connection_timeout' => 10000,  // Connection timeout in milliseconds
-            'socket_timeout' => 5000  // Socket read/write timeout in milliseconds
-        ]
-    );
     ```
   </TabItem>
 


### PR DESCRIPTION
## Summary

Standardizes the ordering of language `<TabItem>` tabs across the docs to the canonical order defined in `AGENTS.md`:

**Python → Java → Node → Go → PHP → C# → Ruby**

Closes #182. Note: the issue predates the Ruby addition and lists `…C#, PHP`, but the current `AGENTS.md` (and the already-compliant pages) use **PHP before C#** with Ruby last. This PR follows the authoritative `AGENTS.md` order, and the scope is the full current set of deviations (26 files), not just the 15 originally listed.

## Changes

- **Reordered 26 doc pages** — all edits are **pure `<TabItem>` block reorders**; no code, prose, or labels changed (verified: sorted file contents are byte-identical to `main`).
- **Added enforcement** (`scripts/check-tab-order.mjs`), since ordering was previously governed only by prose in `AGENTS.md` with no automated check:
  - New `pnpm check:tab-order` script.
  - New **Static Checks** CI step so out-of-order tabs fail PR checks.
  - Ignores non-language tabs (Gradle/Maven, Jedis/Glide, …), handles nested tabs, normalizes `Node.js` → `Node`, and skips languages a page doesn't cover.
- Documented enforcement in `AGENTS.md`.

## Testing

- `node scripts/check-tab-order.mjs` → clean (it flagged all 62 pre-fix violations; 0 after).
- Edge-case tested: correctly flags C#-before-PHP, `Node.js` normalization, single-quote labels, reversed order; correctly ignores non-language tabs, nested non-language tabs, and language subsets.
- `pnpm format:check` → pass.
- `pnpm build` → 111 pages, all internal links valid.